### PR TITLE
Use triple_matches for choosing target

### DIFF
--- a/rbc/tests/test_utils.py
+++ b/rbc/tests/test_utils.py
@@ -1,5 +1,13 @@
-from rbc.utils import is_localhost, get_local_ip
+from rbc.utils import is_localhost, get_local_ip, triple_matches
 
 
 def test_is_localhost():
     assert is_localhost(get_local_ip())
+
+
+def test_triple_matches():
+    assert triple_matches('cuda', 'nvptx64-nvidia-cuda')
+    assert triple_matches('nvptx64-nvidia-cuda', 'cuda')
+    assert triple_matches('cuda32', 'nvptx-nvidia-cuda')
+    assert triple_matches('nvptx-nvidia-cuda', 'cuda32')
+    assert triple_matches('x86_64-pc-linux-gnu', 'x86_64-unknown-linux-gnu')


### PR DESCRIPTION
Fixes:
```
~/Projects/rbc/rbc-env/lib/python3.7/site-packages/rbc_project-0.1.1.dev0-py3.7.egg/rbc/irtools.py in compile_to_LLVM(functions_and_signatures, target, server, use_host_target, debug)
     94                 target_context = target_desc.targetctx
     95         else:
---> 96             raise NotImplementedError(repr((target, cpu_target)))
     97     else:
     98         raise NotImplementedError(repr((target, server)))

NotImplementedError: ('x86_64-pc-linux-gnu', 'x86_64-unknown-linux-gnu')
```