### PR TITLE
Add floating-point equivalent functions to libm whitelist

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -19,9 +19,12 @@ fp_funcs = ['frexp', 'ldexp', 'modf', 'scalbn', 'scalbln', 'nextafter',
             'nexttoward']
 classification_funcs = ['fpclassify', 'isfinite', 'isinf', 'isnan',
                         'isnormal', 'signbit']
-libm_funcs = [*exp_funcs, *power_funcs, *trigonometric_funcs,
-              *hyperbolic_funcs, *nearest_funcs, *fp_funcs,
-              *classification_funcs]
+def lf(l):
+    return l + [e + 'f' for e in l] + [e + 'l' for e in l]
+
+fp_funcs = lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
+              *hyperbolic_funcs, *nearest_funcs, *fp_funcs])
+libm_funcs = [*fp_funcs, *classification_funcs]
 
 
 def get_function_dependencies(module, funcname, _deps=None):

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -26,7 +26,7 @@ classification_funcs = ['fpclassify', 'isfinite', 'isinf', 'isnan',
                         'isnormal', 'signbit']
 
 fp_funcs = _lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
-              *hyperbolic_funcs, *nearest_funcs, *fp_funcs])
+                *hyperbolic_funcs, *nearest_funcs, *fp_funcs])
 libm_funcs = [*fp_funcs, *classification_funcs]
 
 

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -9,8 +9,8 @@ from .targetinfo import TargetInfo
 from .npy_mathimpl import *  # noqa: F403, F401
 
 
-def lf(l):
-    return l + [e + 'f' for e in l] + [e + 'l' for e in l]
+def _lf(lst):
+    return lst + [e + 'f' for e in lst] + [e + 'l' for e in lst]
 
 
 exp_funcs = ['exp', 'exp2', 'expm1', 'log', 'log2', 'log10',
@@ -25,7 +25,7 @@ fp_funcs = ['frexp', 'ldexp', 'modf', 'scalbn', 'scalbln', 'nextafter',
 classification_funcs = ['fpclassify', 'isfinite', 'isinf', 'isnan',
                         'isnormal', 'signbit']
 
-fp_funcs = lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
+fp_funcs = _lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
               *hyperbolic_funcs, *nearest_funcs, *fp_funcs])
 libm_funcs = [*fp_funcs, *classification_funcs]
 

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -8,6 +8,11 @@ import llvmlite.binding as llvm
 from .targetinfo import TargetInfo
 from .npy_mathimpl import *  # noqa: F403, F401
 
+
+def lf(l):
+    return l + [e + 'f' for e in l] + [e + 'l' for e in l]
+
+
 exp_funcs = ['exp', 'exp2', 'expm1', 'log', 'log2', 'log10',
              'log1p', 'ilogb', 'logb']
 power_funcs = ['sqrt', 'cbrt', 'hypot', 'pow']
@@ -19,8 +24,6 @@ fp_funcs = ['frexp', 'ldexp', 'modf', 'scalbn', 'scalbln', 'nextafter',
             'nexttoward']
 classification_funcs = ['fpclassify', 'isfinite', 'isinf', 'isnan',
                         'isnormal', 'signbit']
-def lf(l):
-    return l + [e + 'f' for e in l] + [e + 'l' for e in l]
 
 fp_funcs = lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
               *hyperbolic_funcs, *nearest_funcs, *fp_funcs])

--- a/rbc/tests/test_numpy_rjit.py
+++ b/rbc/tests/test_numpy_rjit.py
@@ -27,8 +27,16 @@ def test_exp2(rjit):
     def exp2(x):
         return np.exp2(x)
 
-    assert (np.allclose(exp2(2), np.exp2(2)))
-    assert (np.allclose(exp2(3), np.exp2(3)))
+    assert (np.isclose(exp2(2), np.exp2(2)))
+    assert (np.isclose(exp2(3), np.exp2(3)))
+
+
+def test_exp2f(rjit):
+    @rjit('float(float)')
+    def exp2(x):
+        return np.exp2(x)
+
+    assert (np.isclose(exp2(2.0), np.exp2(2.0)))
 
 
 def test_logaddexp(rjit):


### PR DESCRIPTION
Fix #43 