### PR TITLE
Skip test_omnisci_math.test_rational_funcs when numba < 0.47

### DIFF
--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from rbc.utils import get_version
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
 
 
@@ -268,6 +269,8 @@ def test_explog_funcs(omnisci):
                 assert(np.isclose(np_fn(x), v))
 
 
+@pytest.mark.skipif(get_version('numba') < (0, 47),
+                    reason="requires numba 0.47 or higher")
 def test_rational_funcs(omnisci):
     omnisci.reset()
 

--- a/rbc/utils.py
+++ b/rbc/utils.py
@@ -7,6 +7,15 @@ import ctypes
 import llvmlite.binding as llvm
 
 
+def get_version(package):
+    """Return a package version as a 3-tuple of integers.
+    """
+    if package == 'numba':
+        import numba
+        return tuple(map(int, numba.__version__.split('.')[:3]))
+    raise NotImplementedError(f'get version of package {package}')
+
+
 def get_local_ip():
     """Return localhost IP.
     """


### PR DESCRIPTION
numpy.gcd support was added to numba 0.47.
Fixes #47 