### PR TITLE
Eliminate forbidden name restriction for OmnisciDB 5.2.

### DIFF
--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -5,12 +5,19 @@ __all__ = ['RemoteJIT', 'Signature', 'Caller']
 
 import os
 import inspect
-
 from . import irtools
-from .typesystem import Type
+from .typesystem import Type, get_signature
 from .thrift import Server, Dispatcher, dispatchermethod, Data, Client
 from .utils import get_local_ip
 from .targetinfo import TargetInfo
+
+
+def isfunctionlike(obj):
+    """Return True if object is function alike.
+    """
+    if obj is None or isinstance(obj, (Signature, list, tuple, str, Caller)):
+        return False
+    return True
 
 
 class Signature(object):
@@ -95,7 +102,7 @@ class Signature(object):
             final(self)  # copies the signatures from self to final
             final(obj.signature)  # copies the signatures from obj to final
             return Caller(obj.func, final)
-        if inspect.isfunction(obj):
+        if isfunctionlike(obj):
             final = Signature(self.remotejit)
             final(self)  # copies the signatures from self to final
             return Caller(obj, final)
@@ -202,7 +209,7 @@ class Caller(object):
         self.remotejit = signature.remotejit
         self.signature = signature
         self.func = func
-        self.nargs = len(inspect.signature(func).parameters)
+        self.nargs = len(get_signature(func).parameters)
 
         # Attributes used in RBC user-interface
         self._is_compiled = set()  # items are (fname, ftype)

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -108,6 +108,10 @@ def test_redefine(omnisci):
 
 
 def test_forbidden_define(omnisci):
+    if omnisci.version > (5, 1):
+        pytest.skip(
+            f'forbidden defines not required for OmnisciDB {omnisci.version}')
+
     omnisci.reset()
 
     msg = "Attempt to define function with name `{name}`"

--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -1,9 +1,9 @@
-import numpy as np
 import pytest
-from rbc.utils import get_version
 
 
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
+np = pytest.importorskip('numpy')
+nb = pytest.importorskip('numba')
 available_version, reason = rbc_omnisci.is_available()
 pytestmark = pytest.mark.skipif(not available_version, reason=reason)
 
@@ -17,12 +17,14 @@ def omnisci():
 
     m.sql_execute(
         'CREATE TABLE IF NOT EXISTS {table_name}'
-        ' (x DOUBLE, y DOUBLE, z DOUBLE, i INT, '
+        ' (a BOOLEAN, b BOOLEAN, x DOUBLE, y DOUBLE, z DOUBLE, i INT, '
         'j INT, t INT[], td DOUBLE[], te INT[]);'
         .format(**locals()))
 
     for _i in range(1, 6):
-        x = _i/10.0
+        a = str((_i % 3) == 0).lower()
+        b = str((_i % 2) == 0).lower()
+        x = 0.7 + _i/10.0
         y = _i/6.0
         z = _i + 1.23
         i = _i
@@ -31,7 +33,7 @@ def omnisci():
         td = 'ARRAY[%s]' % (', '.join(str(j + i/1.0) for i in range(-i, i+1)))
         te = 'Array[]'
         m.sql_execute(
-            'insert into {table_name} values ({x}, {y},'
+            'insert into {table_name} values (\'{a}\', \'{b}\', {x}, {y},'
             ' {z}, {i}, {j}, {t}, {td}, {te})'
             .format(**locals()))
 
@@ -41,394 +43,184 @@ def omnisci():
     m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
 
 
-def test_trigonometric_funcs(omnisci):
+numpy_functions = [
+    # Arithmetic functions:
+    ('absolute', 'double(double)', np.absolute),
+    ('conjugate', 'double(double)', np.conjugate),
+    ('fabs', 'double(double)', np.fabs),
+    ('fmax', 'double(double, double)', np.fmax),
+    ('fmin', 'double(double, double)', np.fmin),
+    ('maximum', 'double(double, double)', np.maximum),
+    ('minimum', 'double(double, double)', np.minimum),
+    ('positive', 'double(double)', np.positive),
+    ('negative', 'double(double)', np.negative),
+    ('sign', 'double(double)', np.sign),
+    ('reciprocal', 'double(double)', np.reciprocal),
+    ('add', 'double(double, double)', np.add),
+    ('subtract', 'double(double, double)', np.subtract),
+    ('multiply', 'double(double, double)', np.multiply),
+    ('divide', 'double(double, double)', np.divide),
+    ('true_divide', 'double(double, double)', np.true_divide),
+    ('floor_divide', 'double(double, double)', np.floor_divide),
+    ('power', 'double(double, double)', np.power),
+    ('float_power', 'double(double, double)', np.float_power),
+    ('square', 'double(double)', np.square),
+    ('sqrt', 'double(double)', np.sqrt),
+    ('cbrt', 'double(double)', np.cbrt),   # not supported by numba
+    ('remainder', 'double(double, double)', np.remainder),
+    ('fmod', 'double(double, double)', np.fmod),
+    ('modf', 'double(double, double)', np.mod),
+    ('modi', 'int(int, int)', np.mod),
+    ('divmod0', 'int(int, int)', lambda i, j: np.divmod(i, j)[0]),
+    # Trigonometric functions:
+    ('sin', 'double(double)', np.sin),
+    ('cos', 'double(double)', np.cos),
+    ('tan', 'double(double)', np.tan),
+    ('arcsin', 'double(double)', np.arcsin),
+    ('arccos', 'double(double)', np.arccos),
+    ('arctan', 'double(double)', np.arctan),
+    ('arctan2', 'double(double, double)', np.arctan2),
+    ('hypot', 'double(double, double)', np.hypot),
+    ('radians', 'double(double)', np.radians),
+    ('rad2deg', 'double(double)', np.rad2deg),
+    ('deg2rad', 'double(double)', np.deg2rad),
+    ('degrees', 'double(double)', np.degrees),
+    # Hyperbolic functions:
+    ('sinh', 'double(double)', np.sinh),
+    ('cosh', 'double(double)', np.cosh),
+    ('tanh', 'double(double)', np.tanh),
+    ('arcsinh', 'double(double)', np.arcsinh),
+    ('arccosh', 'double(double)', np.arccosh),
+    ('arctanh', 'double(double)', np.arctanh),
+    # Exp-log functions:
+    ('exp', 'double(double)', np.exp),
+    ('expm1', 'double(double)', np.expm1),
+    ('exp2', 'double(double)', np.exp2),
+    ('log', 'double(double)', np.log),
+    ('log10', 'double(double)', np.log10),
+    ('log2', 'double(double)', np.log2),
+    ('log1p', 'double(double)', np.log1p),
+    ('logaddexp', 'double(double, double)', np.logaddexp),
+    ('logaddexp2', 'double(double, double)', np.logaddexp2),
+    ('ldexp', 'double(double, int)', np.ldexp),
+    ('frexp0', 'double(double)', lambda x: np.frexp(x)[0]),
+    # Rounding functions:
+    ('around', 'double(double)', lambda x: np.around(x)),
+    ('round2',  # round and round_ are not good names
+     'double(double)', lambda x: np.round_(x)),  # force arity to 1
+    ('floor', 'double(double)', np.floor),
+    ('ceil', 'double(double)', np.ceil),
+    ('trunc', 'double(double)', np.trunc),
+    ('rint', 'double(double)', np.rint),
+    ('spacing', 'double(double)', np.spacing),
+    ('nextafter', 'double(double, double)', np.nextafter),
+    # Rational functions:
+    ('gcd', 'int(int, int)', np.gcd),
+    ('lcm', 'int(int, int)', np.lcm),
+    ('right_shift', 'int(int, int)', np.right_shift),
+    ('left_shift', 'int64(int64, int64)', np.left_shift),
+    # Misc functions
+    ('heaviside', 'double(double, double)', np.heaviside),
+    ('copysign', 'double(double, double)', np.copysign),
+    # Bit functions:
+    ('invert', 'int(int)', np.invert),
+    ('bitwise_or', 'int(int, int)', np.bitwise_or),
+    ('bitwise_xor', 'int(int, int)', np.bitwise_xor),
+    ('bitwise_and', 'int(int, int)', np.bitwise_and),
+    # Logical functions:
+    ('isfinite', 'bool(double)', np.isfinite),
+    ('isinf', 'bool(double)', np.isinf),
+    ('isnan', 'bool(double)', np.isnan),
+    ('signbit', 'bool(double)', np.signbit),
+    ('less', 'bool(double, double)', np.less),
+    ('less_equal', 'bool(double, double)', np.less_equal),
+    ('greater', 'bool(double, double)', np.greater),
+    ('greater_equal', 'bool(double, double)', np.greater_equal),
+    ('equal', 'bool(double, double)', np.equal),
+    ('not_equal', 'bool(double, double)', np.not_equal),
+    ('logical_or', 'bool(bool, bool)', np.logical_or),
+    ('logical_xor', 'bool(bool, bool)', np.logical_xor),
+    ('logical_and', 'bool(bool, bool)', np.logical_and),
+    ('logical_not', 'bool(bool)', np.logical_not),
+    # missing ufunc-s as unsupported: matmul, isnat
+]
+
+if np is not None:
+    for n, f in np.__dict__.items():
+        if n in ['matmul', 'isnat']:  # UNSUPPORTED
+            continue
+        if isinstance(f, np.ufunc):
+            for item in numpy_functions:
+                if item[0].startswith(f.__name__):
+                    break
+            else:
+                print(f'TODO: ADD {n} TEST TO {__file__}')
+
+
+@pytest.mark.parametrize("fn_name, signature, np_func", numpy_functions,
+                         ids=[item[0] for item in numpy_functions])
+def test_numpy_function(omnisci, fn_name, signature, np_func):
     omnisci.reset()
 
-    @omnisci('double(double)')  # noqa: F811
-    def sin(x):
-        return np.sin(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def cos(x):
-        return np.cos(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def tan(x):
-        return np.tan(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def arcsin(x):
-        return np.arcsin(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def arccos(x):
-        return np.arccos(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def arctan(x):
-        return np.arctan(x)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def _hypot(x, y):
-        return np.hypot(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def arctan2(x, y):
-        return np.arctan2(x, y)
-
-    omnisci.register()
-
-    for fn_name in ['sin', 'cos', 'tan', 'arcsin',
-                    'arccos', 'arctan', '_hypot', 'arctan2']:
-        np_fn = getattr(np, fn_name.lstrip('_'))
-
-        if fn_name in ['_hypot', 'arctan2']:
-            descr, result = omnisci.sql_execute(
-                'select x, y, {fn_name}(x, y) from {omnisci.table_name}'
-                .format(**locals()))
-
-            for x, y, v in list(result):
-                assert(np.isclose(np_fn(x, y), v))
+    arity = signature.count(',') + 1
+    kind = signature.split('(')[1].split(',')[0].split(')')[0]
+    if isinstance(np_func, np.ufunc):
+        # numba does not support jitting ufunc-s directly
+        if arity == 1:
+            np_func = eval(f'lambda x: np.{np_func.__name__}(x)', dict(np=np))
+        elif arity == 2:
+            np_func = eval(f'lambda x, y: np.{np_func.__name__}(x, y)',
+                           dict(np=np))
         else:
-            descr, result = omnisci.sql_execute(
-                'select x, {fn_name}(x) from {omnisci.table_name}'
-                .format(**locals()))
+            raise NotImplementedError((signature, arity))
+    if np_func.__name__ == '<lambda>':
+        # give lambda function a name
+        np_func.__name__ = fn_name
 
-            for x, v in list(result):
-                assert(np.isclose(np_fn(x), v))
+    if fn_name in ['logical_or', 'logical_xor', 'logical_and', 'logical_not']:
+        # Invalid use of Function(<ufunc 'logical_or'>) with
+        # argument(s) of type(s): (boolean8, boolean8)
+        pytest.skip(f'using boolean8 as {fn_name} argument not implemented')
 
+    if fn_name in ['positive', 'float_power', 'cbrt', 'divmod0', 'heaviside',
+                   'frexp0']:
+        try:
+            if arity == 1:
+                nb.njit(np_func)(0.5)
+            elif arity == 2:
+                nb.njit(np_func)(0.5, 0.5)
+        except nb.errors.TypingError as msg:
+            msg = str(msg).splitlines()[1]
+            pytest.skip(msg)
 
-def test_hyperbolic_funcs(omnisci):
-    omnisci.reset()
+    if fn_name in ['ldexp', 'spacing', 'nextafter', 'signbit']:
+        pytest.skip(f'{fn_name}: FIXME')
 
-    @omnisci('double(double)')  # noqa: F811
-    def _sinh(x):
-        return np.sinh(x)
+    if omnisci.version < (5, 2) and fn_name in [
+            'sinh', 'cosh', 'tanh', 'rint', 'trunc', 'expm1', 'exp2', 'log2',
+            'log1p', 'gcd', 'lcm', 'around', 'fmod', 'hypot']:
+        # fix forbidden names
+        fn_name += 'FIX'
+        np_func.__name__ = fn_name
 
-    @omnisci('double(double)')  # noqa: F811
-    def _cosh(x):
-        return np.cosh(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _tanh(x):
-        return np.tanh(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def arcsinh(x):
-        return np.arcsinh(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def arccosh(x):
-        return np.arccosh(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def arctanh(x):
-        return np.arctanh(x)
+    omnisci(signature)(np_func)
 
     omnisci.register()
 
-    for fn_name in ['_sinh', '_cosh', '_tanh', 'arcsinh',
-                    'arccosh', 'arctanh']:
-        np_fn = getattr(np, fn_name.lstrip('_'))
-
-        if fn_name == 'arccosh':
-            query = 'select i, z, {fn_name}(i), {fn_name}(z) \
-                     from {omnisci.table_name}'\
-                    .format(**locals())
-
-            descr, result = omnisci.sql_execute(query)
-
-            for i, z, vi, vz in list(result):
-                assert(np_fn(i) == vi)
-                assert(np.isclose(np_fn(z), vz))
+    if kind == 'double':
+        assert arity <= 3, arity
+        xs = ', '.join('xyz'[:arity])
+    elif kind.startswith('int'):
+        assert arity <= 2, arity
+        xs = ', '.join('ij'[:arity])
+    else:
+        raise NotImplementedError(kind)
+    query = f'select {xs}, {fn_name}({xs}) from {omnisci.table_name}'
+    descr, result = omnisci.sql_execute(query)
+    for args in list(result):
+        result = args[-1]
+        expected = np_func(*args[:-1])
+        if np.isnan(expected):
+            assert np.isnan(result)
         else:
-            query = 'select x, {fn_name}(x) from {omnisci.table_name}'\
-                    .format(**locals())
-
-            descr, result = omnisci.sql_execute(query)
-
-            for x, v in list(result):
-                assert(np.isclose(np_fn(x), v))
-
-
-def test_rounding_funcs(omnisci):
-    omnisci.reset()
-
-    @omnisci('double(double)')  # noqa: F811
-    def around(x):
-        return np.around(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def round_(x):
-        return np.round_(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _rint(x):
-        return np.rint(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def floor(x):
-        return np.floor(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def ceil(x):
-        return np.ceil(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _trunc(x):
-        return np.trunc(x)
-
-    omnisci.register()
-
-    for fn_name in ['around', '_rint', 'round_', 'floor', 'ceil', '_trunc']:
-        np_fn = getattr(np, fn_name.lstrip('_'))
-
-        query = 'select x, {fn_name}(x) from {omnisci.table_name}'\
-                .format(**locals())
-
-        descr, result = omnisci.sql_execute(query)
-
-        for x, v in list(result):
-            assert(np.isclose(np_fn(x), v))
-
-
-def test_explog_funcs(omnisci):
-    omnisci.reset()
-
-    @omnisci('double(double)')  # noqa: F811
-    def exp(x):
-        return np.exp(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _expm1(x):
-        return np.expm1(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _exp2(x):
-        return np.exp2(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def log(x):
-        return np.log(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def log10(x):
-        return np.log10(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _log2(x):
-        return np.log2(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def _log1p(x):
-        return np.log1p(x)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def logaddexp(x, y):
-        return np.logaddexp(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def logaddexp2(x, y):
-        return np.logaddexp2(x, y)
-
-    omnisci.register()
-
-    for fn_name in ['exp', '_expm1', '_exp2', 'log', 'log10',
-                    '_log2', '_log1p', 'logaddexp', 'logaddexp2']:
-        np_fn = getattr(np, fn_name.lstrip('_'))
-
-        if fn_name in ['logaddexp', 'logaddexp2']:
-            descr, result = omnisci.sql_execute(
-                'select x, y, {fn_name}(x, y) from {omnisci.table_name}'
-                .format(**locals()))
-
-            for x, y, v in list(result):
-                assert(np.isclose(np_fn(x, y), v))
-        else:
-            descr, result = omnisci.sql_execute(
-                'select x, {fn_name}(x) from {omnisci.table_name}'
-                .format(**locals()))
-
-            for x, v in list(result):
-                assert(np.isclose(np_fn(x), v))
-
-
-@pytest.mark.skipif(get_version('numba') < (0, 47),
-                    reason="requires numba 0.47 or higher")
-def test_rational_funcs(omnisci):
-    omnisci.reset()
-
-    @omnisci('int(int, int)')  # noqa: F811
-    def lcm(i, j):
-        return np.lcm(i, j)
-
-    @omnisci('int(int, int)')  # noqa: F811
-    def gcd(i, j):
-        return np.gcd(i, j)
-
-    omnisci.register()
-
-    for fn_name in ['lcm', 'gcd']:
-        np_fn = getattr(np, fn_name)
-
-        descr, result = omnisci.sql_execute(
-            'select i, j, {fn_name}(i, j) from {omnisci.table_name}'
-            .format(**locals()))
-
-        for i, j, v in list(result):
-            assert(np.isclose(np_fn(i, j), v))
-
-
-@pytest.mark.skipif(available_version < (5, 1),
-                    reason="requires OmnisciDB 5.1 or higher")
-def test_spd_funcs(omnisci):
-    omnisci.reset()
-
-    @omnisci('i32(i32[])', 'double(double[])')
-    def _sum(x):
-        return np.sum(x)
-
-    @omnisci('i64(i32[])', 'double(double[])')
-    def _prod(x):
-        return np.prod(x)
-
-    omnisci.register()
-
-    for fn_name in ['_sum', '_prod']:
-        np_fn = getattr(np, fn_name.lstrip('_'))
-
-        # int list
-        descr, result = omnisci.sql_execute(
-            'select t, {fn_name}(t) from {omnisci.table_name}'
-            .format(**locals()))
-
-        for t, v in list(result):
-            assert(np_fn(t) == v)
-
-        # double list
-        descr, result = omnisci.sql_execute(
-            'select td, {fn_name}(td) from {omnisci.table_name}'
-            .format(**locals()))
-
-        for td, v in list(result):
-            assert(np.isclose(np_fn(td), v))
-
-        # empty list
-        descr, result = omnisci.sql_execute(
-            'select te, {fn_name}(te) from {omnisci.table_name}'
-            .format(**locals()))
-
-        for te, v in list(result):
-            assert(np_fn([]) == v)
-
-
-def test_arithmetic_funcs(omnisci):
-    omnisci.reset()
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def add(i, j):
-        return np.add(i, j)
-
-    @omnisci('double(double)')  # noqa: F811
-    def reciprocal(x):
-        return np.reciprocal(x)
-
-    @omnisci('double(double)')  # noqa: F811
-    def negative(x):
-        return np.negative(x)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def multiply(x, y):
-        return np.multiply(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def divide(x, y):
-        return np.divide(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def _power(x, y):
-        return np.power(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def subtract(x, y):
-        return np.subtract(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def true_divide(x, y):
-        return np.true_divide(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def floor_divide(x, y):
-        return np.floor_divide(x, y)
-
-    @omnisci('double(double, double)')
-    def _fmod(x, y):
-        return np.fmod(x, y)
-
-    @omnisci('int(int, int)', 'double(double, double)')  # noqa: F811
-    def mod(x, y):
-        return np.mod(x, y)
-
-    @omnisci('double(double, double)')  # noqa: F811
-    def remainder(x, y):
-        return np.remainder(x, y)
-
-    omnisci.register()
-
-    all_funcs = set(['add', 'reciprocal', 'negative', 'multiply',
-                     'divide', '_power', 'subtract', 'true_divide',
-                     'floor_divide', '_fmod', 'mod', 'remainder'])
-
-    exclude = set(['reciprocal', 'negative', 'remainder'])
-
-    for fn_name in all_funcs:
-
-        np_fn = getattr(np, fn_name.lstrip('_'))
-
-        if fn_name in ['reciprocal', 'negative']:
-            descr, result = omnisci.sql_execute(
-                'select x, {fn_name}(x) from {omnisci.table_name}'
-                .format(**locals()))
-
-            for x, v in list(result):
-                assert(np.isclose(np_fn(x), v))
-
-        if fn_name in ['mod', 'remainder']:
-            descr, result = omnisci.sql_execute(
-                'select i, j, {fn_name}(i, j) from {omnisci.table_name}'
-                .format(**locals()))
-
-            for i, j, v in list(result):
-                assert(np.isclose(np_fn(i, j), v))
-
-        if fn_name in all_funcs.difference(exclude):
-            descr, result = omnisci.sql_execute(
-                'select x, y, {fn_name}(x, y) from {omnisci.table_name}'
-                .format(**locals()))
-
-            for x, y, v in list(result):
-                assert(np.isclose(np_fn(x, y), v))
-
-
-def test_multiple_fns(omnisci):
-
-    omnisci.reset()
-
-    @omnisci('double(double, double)')
-    def multiple1(x, y):
-        a = np.add(x, y)
-        b = np.multiply(x, y)
-        c = np.add(a, b)
-        d = np.power(c, c)
-        return np.trunc(d)
-
-    omnisci.register()
-
-    _, result = omnisci.sql_execute(
-        'select x, x, multiple1(x, y) from {omnisci.table_name}'
-        .format(**locals()))
-
-    expected = multiple1.func(np.arange(1, 6)/10.0, np.arange(1, 6)/6.0)
-
-    for exp, (_, _, got) in zip(expected, result):
-        assert (exp == got)
+            assert(np.isclose(expected, result))

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -1099,9 +1099,6 @@ if nb is not None:
         def can_convert_from(self, typingctx, other):
             return isinstance(other, numba.types.Boolean)
 
-        def unify(self, context, other):
-            print('UNIFY', other)
-
     @numba.datamodel.register_default(Boolean8)
     class Boolean8Model(numba.datamodel.models.BooleanModel):
 
@@ -1121,10 +1118,6 @@ if nb is not None:
     def literal_boolean_to_booleanN(context, builder, fromty, toty, val):
         llty = context.get_value_type(toty)
         return builder.zext(val, llty)
-
-    @numba.extending.unbox(Boolean8)
-    def unbox_boolean8(typ, obj, c):
-        print('unbox_boolean8', typ, obj)
 
 
 def make_numba_struct(name, members, _cache={}):
@@ -1163,7 +1156,7 @@ def get_signature(obj):
             m = _ufunc_pos_args_match(sigline)
             name = m['name']
             assert name == obj.__name__, (name, obj.__name__)
-            # rest = m['rest']
+
             # positional arguments
             m = _req_opt_args_match(m['pos_args'])
             req_pos_names, opt_pos_names = [], []
@@ -1180,7 +1173,7 @@ def get_signature(obj):
                     opt_pos_names.append(n)
                     parameters[n] = inspect.Parameter(
                         n, inspect.Parameter.POSITIONAL_ONLY, default=None)
-            # TODO: process non-positional arguments in `rest`
+            # TODO: process non-positional arguments in `m['rest']`
 
             # scan for annotations and determine returns
             mode = 'none'


### PR DESCRIPTION
The forbidden name restriction is removed by using name mangling `__<id>` for all low-level function names. This requires the usage of https://github.com/omnisci/omniscidb-internal/pull/4133

This PR also revised omnisci math tests and fixes various bugs with boolean support.

Fixes: #32 