### PR TITLE
Bug-fix release 0.2.2

### DIFF
--- a/rbc/__init__.py
+++ b/rbc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0dev0'
+__version__ = '0.2.2'
 
 # Expose a temporary prototype. It will be replaced by proper
 # implementation soon.

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -181,6 +181,7 @@ class RemoteOmnisci(RemoteJIT):
         self._targets = None
         self.thrift_typemap = defaultdict(dict)
         self._init_thrift_typemap()
+        self.has_cuda = None
 
     def _init_thrift_typemap(self):
         """Initialize thrift type map using client thrift configuration.
@@ -370,6 +371,7 @@ class RemoteOmnisci(RemoteJIT):
                     continue
                 target_info.set(prop[len(device)+1:], value)
             if device == 'gpu':
+                self.has_cuda = True
                 # TODO: remove this hack
                 # see https://github.com/numba/numba/issues/4546
                 target_info.set('name', 'skylake')

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -202,6 +202,9 @@ def test_getitem_float(omnisci):
         assert type(a[2]) == type(item)
 
 
+@pytest.mark.skipif(available_version[:2] == (5, 1),
+                    reason="skip due to a bug in omniscidb 5.1 (got %s)" % (
+                        available_version,))
 def test_getitem_bool(omnisci):
     omnisci.reset()
 
@@ -234,6 +237,9 @@ def test_sum(omnisci):
         assert sum(a) == s
 
 
+@pytest.mark.skipif(available_version[:2] == (5, 1),
+                    reason="skip due to a bug in omniscidb 5.1 (got %s)" % (
+                        available_version,))
 def test_even_sum(omnisci):
     omnisci.reset()
 

--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -196,6 +196,20 @@ def test_numpy_function(omnisci, fn_name, signature, np_func):
     if fn_name in ['ldexp', 'spacing', 'nextafter', 'signbit']:
         pytest.skip(f'{fn_name}: FIXME')
 
+    if omnisci.has_cuda and fn_name in [
+            'arcsin', 'arccos', 'arctan', 'arctan2', 'hypot', 'sinh', 'cosh',
+            'tanh', 'arcsinh', 'arccosh', 'arctanh', 'expm1', 'exp2', 'log2',
+            'log1p', 'logaddexp2']:
+        # https://github.com/xnd-project/rbc/issues/59
+        pytest.skip(f'{fn_name}: crashes CUDA enabled omniscidb server'
+                    ' [rbc issue 59]')
+
+    if omnisci.has_cuda and fn_name in [
+            'logaddexp']:
+        # https://github.com/xnd-project/rbc/issues/60
+        pytest.skip(f'{fn_name}: crashes CUDA enabled omniscidb server'
+                    ' [rbc issue 60]')
+
     if omnisci.version < (5, 2) and fn_name in [
             'sinh', 'cosh', 'tanh', 'rint', 'trunc', 'expm1', 'exp2', 'log2',
             'log1p', 'gcd', 'lcm', 'around', 'fmod', 'hypot']:

--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -217,6 +217,16 @@ def test_numpy_function(omnisci, fn_name, signature, np_func):
         fn_name += 'FIX'
         np_func.__name__ = fn_name
 
+    if omnisci.version < (5, 2) and omnisci.has_cuda and fn_name in [
+            'fmax', 'fmin', 'power', 'sqrt', 'tan', 'radians', 'degrees'
+    ]:
+        # NativeCodegen.cpp:849 use of undefined value '@llvm.maxnum.f64'
+        # NativeCodegen.cpp:849 invalid redefinition of function 'power'
+        # NativeCodegen.cpp:849 invalid redefinition of function
+        #                       'llvm.lifetime.start.p0i8'
+        # NativeCodegen.cpp:849 invalid redefinition of function 'radians'
+        pytest.skip(f'{fn_name}: crashes CUDA enabled omniscidb server < 5.2')
+
     omnisci(signature)(np_func)
 
     omnisci.register()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ CONDA_BUILD = int(os.environ.get('CONDA_BUILD', '0'))
 
 from setuptools import setup, find_packages  # noqa: E402
 
-VERSION = '0.3.0dev0'  # for release, remove dev? part
+VERSION = '0.2.2'  # for release, remove dev? part
 DESCRIPTION = "RBC - Remote Backend Compiler Project"
 LONG_DESCRIPTION = """
 The aim of the Remote Backend Compiler project is to distribute the


### PR DESCRIPTION
Release notes:
- Fixes UDTF regression
- Implement OmniSci Array setitem (PR https://github.com/xnd-project/rbc/pull/56)

Tests:
- [ ] omniscidb-internal NOCUDA
  - [x] master, Arrow 0.16
    - build failure `ThirdParty/googlebenchmark/src/benchmark_register.cc:37:0: error: "__STDC_FORMAT_MACROS" redefined`
    - fix available in https://github.com/omnisci/omniscidb-internal/pull/4370
  - [ ] 5.1.2, Arrow 0.13
    - build failure `error: 'ERR__MAX_POLL_EXCEEDED' is not a member of 'RdKafka'`
  - [x] 5.1.1
  - [x] 5.1.0
  - [x] 5.0.1
  - [x] 5.0.0
- [ ] omniscidb-internal CUDA
  - [x] master
    - build failure `StringTransform.h:28:10: fatal error: boost/config.hpp: No such file or directory`
    - fix available in https://github.com/omnisci/omniscidb-internal/pull/4370
    - https://github.com/xnd-project/rbc/issues/59 - server crash when calling arcsin, etc, tests disabled.
    - https://github.com/xnd-project/rbc/issues/60 - server crash, test disabled
  - [x] 5.1.1
    - cmake failure `CUDA_CUDA_LIBRARY (ADVANCED)` not found, as fix run `conda install -c conda-forge nvcc_linux-64 cudatoolkit`
    - need to apply `ifndef __CUDACC__` patch
  - [ ] 5.0.0
    - build failure `include/llvm/Object/SymbolicFile.h:47:31: error: expected ')' before 'PRIxPTR'`
