### PR TITLE
Initial support for Array(dtype, size)

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -52,6 +52,8 @@ def get_function_dependencies(module, funcname, _deps=None):
                 elif f.is_declaration:
                     if name in libm_funcs:
                         _deps[name] = 'libm'
+                    elif name == 'allocate_varlen_buffer':
+                        _deps[name] = 'omnisci_internal'
                     else:
                         _deps[name] = 'undefined'
                 else:

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -146,6 +146,9 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo, debug=False):
         # Bring over Array overloads (a hack):
         target_context._defns = target_desc.target_context._defns
 
+    typing_context.target_info = target
+    target_context.target_info = target
+
     codegen = target_context.codegen()
     main_library = codegen.create_library('rbc.irtools.compile_to_IR')
     main_module = main_library._final_module

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -36,7 +36,6 @@ fp_funcs = _lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
                 *hyperbolic_funcs, *nearest_funcs, *fp_funcs])
 libm_funcs = [*fp_funcs, *classification_funcs]
 
-omnisci_funcs = ['allocate_varlen_buffer', 'executor']
 
 def get_function_dependencies(module, funcname, _deps=None):
     if _deps is None:
@@ -53,7 +52,7 @@ def get_function_dependencies(module, funcname, _deps=None):
                 elif f.is_declaration:
                     if name in libm_funcs:
                         _deps[name] = 'libm'
-                    elif name in omnisci_funcs:
+                    elif name == 'allocate_varlen_buffer':
                         _deps[name] = 'omnisci_internal'
                     else:
                         _deps[name] = 'undefined'

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -36,6 +36,7 @@ fp_funcs = _lf([*exp_funcs, *power_funcs, *trigonometric_funcs,
                 *hyperbolic_funcs, *nearest_funcs, *fp_funcs])
 libm_funcs = [*fp_funcs, *classification_funcs]
 
+omnisci_funcs = ['allocate_varlen_buffer', 'executor']
 
 def get_function_dependencies(module, funcname, _deps=None):
     if _deps is None:
@@ -52,7 +53,7 @@ def get_function_dependencies(module, funcname, _deps=None):
                 elif f.is_declaration:
                     if name in libm_funcs:
                         _deps[name] = 'libm'
-                    elif name == 'allocate_varlen_buffer':
+                    elif name in omnisci_funcs:
                         _deps[name] = 'omnisci_internal'
                     else:
                         _deps[name] = 'undefined'

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -20,8 +20,8 @@ class ArrayPointer(types.Type):
     mutable = True
 
     def __init__(self, dtype, eltype):
-        self.dtype = dtype # i.e. STRUCT__lPLBK
-        self.eltype = eltype # i.e. int64. Base type for dtype: Array<int64>
+        self.dtype = dtype  # i.e. STRUCT__lPLBK
+        self.eltype = eltype  # i.e. int64. Base type for dtype: Array<int64>
         name = "(%s)*" % dtype
         super(ArrayPointer, self).__init__(name)
 
@@ -32,6 +32,7 @@ class ArrayPointer(types.Type):
 
 class Array(object):
     pass
+
 
 # XXX there should be a better way to find element size
 bytes_map = {
@@ -53,12 +54,12 @@ def omnisci_array_constructor(context, builder, sig, args):
     # grab args
     _, sz = args
     dtype = sig.args[0].literal_value.strip('[]')
-    elsize = bytes_map[dtype] # element size in bytes
+    elsize = bytes_map[dtype]  # element size in bytes
 
     # fill 'sz' and 'is_null'
     typ = sig.return_type.dtype
-    fa = cgutils.create_struct_proxy(typ)(context, builder) 
-    fa.sz = builder.zext(sz, i64) # zero-extend the size to i64
+    fa = cgutils.create_struct_proxy(typ)(context, builder)
+    fa.sz = builder.zext(sz, i64)  # zero-extend the size to i64
     fa.is_null = ir.Constant(i8, 0)
 
     # fill 'ptr' with the return value of 'allocate_varlen_buffer'

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -56,13 +56,6 @@ def omnisci_array_constructor(context, builder, sig, args, elsize):
     call = builder.call(fn, [fa.sz, i64(elsize.bits)])
     fa.ptr = builder.bitcast(call, elsize_ir.as_pointer())
 
-    # executor call
-    fn_executor = pyapi._get_function(
-        ir.FunctionType(i8.as_pointer(), []),
-        name='executor')
-    c = builder.call(fn_executor, [])
-    # cgutils.printf(builder, "result: %d\n", c)
-
     return fa._getpointer()
 
 

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -47,7 +47,7 @@ def omnisci_array_constructor(context, builder, signature, args):
     sz, _ = args
     dtype = signature.args[1].literal_value
     elsize = typesystem.Type.fromstring(dtype, targetinfo)  # element size
-    elsize_ir = context.get_value_type(elsize.tonumba())  # get the llvmlite correspondent type
+    elsize_ir = context.get_value_type(elsize.tonumba())  # get the ir type
 
     # fill 'sz' and 'is_null'
     typ = signature.return_type.dtype

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -56,6 +56,13 @@ def omnisci_array_constructor(context, builder, sig, args, elsize):
     call = builder.call(fn, [fa.sz, i64(elsize.bits)])
     fa.ptr = builder.bitcast(call, elsize_ir.as_pointer())
 
+    # executor call
+    fn_executor = pyapi._get_function(
+        ir.FunctionType(i8.as_pointer(), []),
+        name='executor')
+    c = builder.call(fn_executor, [])
+    # cgutils.printf(builder, "result: %d\n", c)
+
     return fa._getpointer()
 
 

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -34,7 +34,7 @@ class Array(object):
     pass
 
 
-def omnisci_array_constructor(context, builder, signature, args, elsize):
+def omnisci_array_constructor(context, builder, sig, args, elsize):
     pyapi = context.get_python_api(builder)
 
     # integer types used
@@ -46,7 +46,7 @@ def omnisci_array_constructor(context, builder, signature, args, elsize):
     elsize_ir = context.get_value_type(elsize.tonumba())  # get the ir type
 
     # fill 'sz' and 'is_null'
-    typ = signature.return_type.dtype
+    typ = sig.return_type.dtype
     fa = cgutils.create_struct_proxy(typ)(context, builder)
     fa.sz = builder.zext(sz, i64)  # zero-extend the size to i64
     fa.is_null = i8(0)
@@ -61,23 +61,23 @@ def omnisci_array_constructor(context, builder, signature, args, elsize):
 
 
 @extending.lower_builtin(Array, types.Integer, types.StringLiteral)
-def omnisci_array_constructor_string_literal(context, builder, signature, args):
+def omnisci_array_constructor_string_literal(context, builder, sig, args):
     targetinfo = TargetInfo.host()
 
-    dtype = signature.args[1].literal_value
+    dtype = sig.args[1].literal_value
     elsize = typesystem.Type.fromstring(dtype, targetinfo)  # element size
 
-    return omnisci_array_constructor(context, builder, signature, args, elsize)
+    return omnisci_array_constructor(context, builder, sig, args, elsize)
 
 
 @extending.lower_builtin(Array, types.Integer, types.NumberClass)
-def omnisci_array_constructor_numba_type(context, builder, signature, args):
+def omnisci_array_constructor_numba_type(context, builder, sig, args):
     targetinfo = TargetInfo.host()
 
-    it = signature.args[1].instance_type
+    it = sig.args[1].instance_type
     elsize = typesystem.Type.fromnumba(it, targetinfo)
 
-    return omnisci_array_constructor(context, builder, signature, args, elsize)
+    return omnisci_array_constructor(context, builder, sig, args, elsize)
 
 
 @extending.type_callable(Array)

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -43,7 +43,7 @@ bytes_map = {
 }
 
 
-@extending.lower_builtin(Array, types.Any, types.Any)
+@extending.lower_builtin(Array, types.StringLiteral, types.Integer)
 def omnisci_array_constructor(context, builder, sig, args):
     pyapi = context.get_python_api(builder)
 

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -211,7 +211,7 @@ def test_getitem_bool(omnisci):
     @omnisci('bool(bool[], int64)')
     def array_getitem_bool(x, i):
         return x[i]
-    print(array_getitem_bool)
+
     query = ('select b, array_getitem_bool(b, 2) from {omnisci.table_name}'
              .format(**locals()))
     desrc, result = omnisci.sql_execute(query)
@@ -288,9 +288,9 @@ def test_array_constructor_len(omnisci):
     from rbc.omnisci_array import Array
     from numba import types
 
-    @omnisci('int64(int64)')
+    @omnisci('int64(int32)')
     def array_len(size):
-        a = Array(size, types.int32)
+        a = Array(size, types.float64)
         return len(a)
 
     query = (

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -289,11 +289,11 @@ def test_array_constructor_len(omnisci):
 
     @omnisci('int64(int64)')
     def array_len(size):
-        a = Array('double[]', size)
+        a = Array('int64[]', size)
         return len(a)
 
     query = (
-        'select array_len(3) from {omnisci.table_name}'
+        'array_len(30)'
         .format(**locals()))
     _, result = omnisci.sql_execute(query)
 
@@ -307,9 +307,9 @@ def test_array_constructor_ptr(omnisci):
 
     @omnisci('int32(int32)')
     def array_ptr(size):
-        a = Array('int32[]', size)
+        a = Array(size, 'double')
         for i in range(size):
-            a[i] = i
+            a[i] = i + 0.0
         return a[2]
 
     query = (
@@ -327,7 +327,7 @@ def test_array_constructor_sz(omnisci):
 
     @omnisci('int64(int64)')
     def array_size(size):
-        a = Array('double[]', size)
+        a = Array('int8[]', size)
         return len(a)
 
     query = (
@@ -345,11 +345,11 @@ def test_array_constructor_is_null(omnisci):
 
     @omnisci('int8(int64)')
     def array_is_null(size):
-        a = Array('double[]', size)
-        return a.is_null
+        a = Array(size, 'double')
+        return a.is_null()
 
     query = (
-        'select array_is_null(3) from {omnisci.table_name}'
+        'select array_is_null(3);'
         .format(**locals()))
     _, result = omnisci.sql_execute(query)
 

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -293,8 +293,6 @@ def test_array_constructor_len(omnisci):
         a = Array(size, types.int32)
         return len(a)
 
-    print(str(array_len))
-
     query = (
         'select array_len(30)'
         .format(**locals()))

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -262,7 +262,7 @@ def test_even_sum(omnisci):
 
 def test_array_setitem(omnisci):
     omnisci.reset()
-    
+
     @omnisci('double(double[], int32)')
     def array_setitem_sum(b, c):
         n = len(b)

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -286,10 +286,11 @@ def test_array_constructor_len(omnisci):
     omnisci.reset()
 
     from rbc.omnisci_array import Array
+    from numba import types
 
     @omnisci('int64(int64)')
     def array_len(size):
-        a = Array(size, 'int64')
+        a = Array(size, types.int32)
         return len(a)
 
     query = (
@@ -304,10 +305,11 @@ def test_array_constructor_getitem(omnisci):
     omnisci.reset()
 
     from rbc.omnisci_array import Array
+    import numpy as np
 
     @omnisci('double(int32, int32)')
     def array_ptr(size, pos):
-        a = Array(size, 'double')
+        a = Array(size, np.double)
         for i in range(size):
             a[i] = i + 0.0
         return a[pos]

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -293,6 +293,8 @@ def test_array_constructor_len(omnisci):
         a = Array(size, types.int32)
         return len(a)
 
+    print(str(array_len))
+
     query = (
         'select array_len(30)'
         .format(**locals()))

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -282,21 +282,75 @@ def test_array_setitem(omnisci):
         assert sum(f8) * 4 == s
 
 
-def test_array_constructor(omnisci):
+def test_array_constructor_len(omnisci):
     omnisci.reset()
 
-    from rbc.omnisci_array import Array, ArrayPointer
-    from numba import types
+    from rbc.omnisci_array import Array
 
     @omnisci('int64(int64)')
-    def array_constructor(size):
-        a = Array('int64[]', size)
+    def array_len(size):
+        a = Array('double[]', size)
         return len(a)
 
     query = (
-        'select array_constructor(5) from {omnisci.table_name}'
+        'select array_len(3) from {omnisci.table_name}'
         .format(**locals()))
     _, result = omnisci.sql_execute(query)
 
     print(list(result))
 
+
+def test_array_constructor_ptr(omnisci):
+    omnisci.reset()
+
+    from rbc.omnisci_array import Array
+
+    @omnisci('int32(int32)')
+    def array_ptr(size):
+        a = Array('int32[]', size)
+        for i in range(size):
+            a[i] = i
+        return a[2]
+
+    query = (
+        'select array_ptr(3) from {omnisci.table_name}'
+        .format(**locals()))
+    _, result = omnisci.sql_execute(query)
+
+    print(list(result))
+
+
+def test_array_constructor_sz(omnisci):
+    omnisci.reset()
+
+    from rbc.omnisci_array import Array
+
+    @omnisci('int64(int64)')
+    def array_size(size):
+        a = Array('double[]', size)
+        return len(a)
+
+    query = (
+        'select array_size(3) from {omnisci.table_name}'
+        .format(**locals()))
+    _, result = omnisci.sql_execute(query)
+
+    print(list(result))
+
+
+def test_array_constructor_is_null(omnisci):
+    omnisci.reset()
+
+    from rbc.omnisci_array import Array
+
+    @omnisci('int8(int64)')
+    def array_is_null(size):
+        a = Array('double[]', size)
+        return a.is_null
+
+    query = (
+        'select array_is_null(3) from {omnisci.table_name}'
+        .format(**locals()))
+    _, result = omnisci.sql_execute(query)
+
+    print(list(result))

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -262,7 +262,7 @@ def test_even_sum(omnisci):
 
 def test_array_setitem(omnisci):
     omnisci.reset()
-
+    
     @omnisci('double(double[], int32)')
     def array_setitem_sum(b, c):
         n = len(b)
@@ -280,3 +280,23 @@ def test_array_setitem(omnisci):
 
     for f8, s in result:
         assert sum(f8) * 4 == s
+
+
+def test_array_constructor(omnisci):
+    omnisci.reset()
+
+    from rbc.omnisci_array import Array, ArrayPointer
+    from numba import types
+
+    @omnisci('int64(int64)')
+    def array_constructor(size):
+        a = Array('int64[]', size)
+        return len(a)
+
+    query = (
+        'select array_constructor(5) from {omnisci.table_name}'
+        .format(**locals()))
+    _, result = omnisci.sql_execute(query)
+
+    print(list(result))
+

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -289,53 +289,35 @@ def test_array_constructor_len(omnisci):
 
     @omnisci('int64(int64)')
     def array_len(size):
-        a = Array('int64[]', size)
+        a = Array(size, 'int64')
         return len(a)
 
     query = (
-        'array_len(30)'
+        'select array_len(30)'
         .format(**locals()))
     _, result = omnisci.sql_execute(query)
 
-    print(list(result))
+    assert list(result)[0] == (30,)
 
 
-def test_array_constructor_ptr(omnisci):
+def test_array_constructor_getitem(omnisci):
     omnisci.reset()
 
     from rbc.omnisci_array import Array
 
-    @omnisci('int32(int32)')
-    def array_ptr(size):
+    @omnisci('double(int32, int32)')
+    def array_ptr(size, pos):
         a = Array(size, 'double')
         for i in range(size):
             a[i] = i + 0.0
-        return a[2]
+        return a[pos]
 
     query = (
-        'select array_ptr(3) from {omnisci.table_name}'
+        'select array_ptr(5, 3)'
         .format(**locals()))
     _, result = omnisci.sql_execute(query)
 
-    print(list(result))
-
-
-def test_array_constructor_sz(omnisci):
-    omnisci.reset()
-
-    from rbc.omnisci_array import Array
-
-    @omnisci('int64(int64)')
-    def array_size(size):
-        a = Array('int8[]', size)
-        return len(a)
-
-    query = (
-        'select array_size(3) from {omnisci.table_name}'
-        .format(**locals()))
-    _, result = omnisci.sql_execute(query)
-
-    print(list(result))
+    assert list(result)[0] == (3.0,)
 
 
 def test_array_constructor_is_null(omnisci):
@@ -353,4 +335,4 @@ def test_array_constructor_is_null(omnisci):
         .format(**locals()))
     _, result = omnisci.sql_execute(query)
 
-    print(list(result))
+    assert list(result)[0] == (0,)

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -720,6 +720,8 @@ class Type(tuple):
             return cls(rtype, tuple(atypes) or (Type(),))
         if isinstance(t, nb.types.misc.CPointer):
             return cls(cls.fromnumba(t.dtype, target_info), '*')
+        if isinstance(t, nb.types.NumberClass):
+            return cls.fromnumba(t.instance_type, target_info)
         raise NotImplementedError(repr(t))
 
     @classmethod


### PR DESCRIPTION
Still a work in progress. 

This PR adds the ability to instantiate an Omnisci array inside a jitted code.

I will keep the list below as a To-Do list:
- [x] Find a way to get `TargetInfo`  inside `type_omnisci_array` or `array_type_converter`
- [x] Formalize the signature used to construct arrays. Are we down for using the type as a string? i. e. `int32[]`. 
- [x] Find a way to get the length in bytes of the type `T`. OmniSci uses a `reinterpreter_cast<T>` but we don't have this fancy machinery at hand. The typesystem can be used in this case: `typesystem.Type.fromstring(int32).bits`
- [ ] Check how memory is released
- [x] Change tests to eval an expression without a `table` statement.
- [x] Change the order of arguments inside the constructor
- [x] Remove square brackets from the dtype when constructing a new array
- [x] Add a method to access the `is_null` property
- [x] Support other types on `dtype`. i.e. `Array(size, dtype=types.int32)` or `Array(size, dtype=np.int32)`