### PR TITLE
Omnisci Memory management

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -254,6 +254,7 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo, debug=False):
                                           flags=flags,
                                           library=main_library,
                                           locals={},
+                                        #   pipeline_class=Pipeline,)
                                           pipeline_class=OmnisciCompilerPipeline)
             make_wrapper(fname, args, return_type, cres)
 

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -7,7 +7,6 @@ import llvmlite.binding as llvm
 from .targetinfo import TargetInfo
 from .npy_mathimpl import *  # noqa: F403, F401
 from .utils import get_version
-from .omnisci_pipeline import OmnisciCompilerPipeline
 if get_version('numba') >= (0, 49):
     from numba.core import codegen, cpu, compiler_lock, \
         registry, typing, compiler, sigutils, cgutils, \
@@ -239,8 +238,6 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo,
     flags = compiler.Flags()
     flags.set('no_compile')
     flags.set('no_cpython_wrapper')
-
-    pipeline_class = OmnisciCompilerPipeline
 
     function_names = []
     for func, signatures in functions_and_signatures:

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -239,6 +239,8 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo, debug=False):
     flags.set('no_compile')
     flags.set('no_cpython_wrapper')
 
+    pipeline_class = OmnisciCompilerPipeline
+
     function_names = []
     for func, signatures in functions_and_signatures:
         for sig in signatures:
@@ -254,8 +256,7 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo, debug=False):
                                           flags=flags,
                                           library=main_library,
                                           locals={},
-                                        #   pipeline_class=Pipeline,)
-                                          pipeline_class=OmnisciCompilerPipeline)
+                                          pipeline_class=pipeline_class)
             make_wrapper(fname, args, return_type, cres)
 
     seen = set()

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -200,7 +200,8 @@ def make_wrapper(fname, atypes, rtype, cres):
     cres.library.add_ir_module(module)
 
 
-def compile_to_LLVM(functions_and_signatures, target: TargetInfo, debug=False):
+def compile_to_LLVM(functions_and_signatures, target: TargetInfo,
+                    pipeline_class=compiler.Compiler, debug=False):
     """Compile functions with given signatures to target specific LLVM IR.
 
     Parameters

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -7,6 +7,7 @@ import llvmlite.binding as llvm
 from .targetinfo import TargetInfo
 from .npy_mathimpl import *  # noqa: F403, F401
 from .utils import get_version
+from .omnisci_pipeline import OmnisciCompilerPipeline
 if get_version('numba') >= (0, 49):
     from numba.core import codegen, cpu, compiler_lock, \
         registry, typing, compiler, sigutils, cgutils, \
@@ -252,7 +253,8 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo, debug=False):
                                           return_type=return_type,
                                           flags=flags,
                                           library=main_library,
-                                          locals={})
+                                          locals={},
+                                          pipeline_class=OmnisciCompilerPipeline)
             make_wrapper(fname, args, return_type, cres)
 
     seen = set()

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -61,7 +61,6 @@ def omnisci_array_constructor(context, builder, sig, args, elsize):
         ir.FunctionType(i8.as_pointer(), []),
         name='executor')
     c = builder.call(fn_executor, [])
-    # cgutils.printf(builder, "result: %d\n", c)
 
     return fa._getpointer()
 

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -66,7 +66,6 @@ def omnisci_array_constructor(context, builder, sig, args):
     alloc_fn = builder.module.get_or_insert_function(
         alloc_fnty, name="allocate_varlen_buffer")
     ptr8 = builder.call(alloc_fn, [element_count, element_size])
-    cgutils.printf(builder, "[Malloc] allocating array %p\n", ptr8)
     builder_buffers[builder].append(ptr8)
     ptr = builder.bitcast(ptr8, context.get_value_type(ptr_type))
     is_null = context.get_value_type(null_type)(0)

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -88,12 +88,7 @@ def type_omnisci_array(context):
 
 @datamodel.register_default(ArrayPointer)
 class ArrayPointerModel(datamodel.models.PointerModel):
-
-    def as_return(self, builder, value):
-        """This method is called on `return a` statement where `a` is Omnisci
-        Array instance.
-        """
-        return value
+    pass
 
 
 @extending.intrinsic

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -66,7 +66,7 @@ def omnisci_array_constructor(context, builder, sig, args):
     alloc_fn = builder.module.get_or_insert_function(
         alloc_fnty, name="allocate_varlen_buffer")
     ptr8 = builder.call(alloc_fn, [element_count, element_size])
-    cgutils.printf(builder, "allocating array %p\n", ptr8)
+    cgutils.printf(builder, "[Malloc] allocating array %p\n", ptr8)
     builder_buffers[builder].append(ptr8)
     ptr = builder.bitcast(ptr8, context.get_value_type(ptr_type))
     is_null = context.get_value_type(null_type)(0)

--- a/rbc/omnisci_pipeline.py
+++ b/rbc/omnisci_pipeline.py
@@ -64,8 +64,8 @@ class FreeOmnisciArray(FunctionPass):
 
         for blk in func_ir.blocks.values():
             for stmt in blk.find_insts(ir.Assign):
-                if isinstance(stmt.value, ir.FreeVar) and \
-                    stmt.value.name == 'Array':
+                if isinstance(stmt.value, ir.FreeVar) \
+                   and stmt.value.name == 'Array':
                     found = True
 
         if not found:

--- a/rbc/omnisci_pipeline.py
+++ b/rbc/omnisci_pipeline.py
@@ -60,7 +60,17 @@ class FreeOmnisciArray(FunctionPass):
     # state from the CompilerBase instance.
     def run_pass(self, state):
         func_ir = state.func_ir  # get the FunctionIR object
-        mutated = False  # used to record whether this pass mutates the IR
+        found = False
+
+        for blk in func_ir.blocks.values():
+            for stmt in blk.find_insts(ir.Assign):
+                if isinstance(stmt.value, ir.FreeVar) and \
+                    stmt.value.name == 'Array':
+                    found = True
+
+        if not found:
+            return False
+
         for blk in func_ir.blocks.values():
             loc = blk.loc
             scope = blk.scope
@@ -79,7 +89,7 @@ class FreeOmnisciArray(FunctionPass):
                 blk.insert_before_terminator(var)
                 break
 
-        return mutated
+        return True
 
 
 class OmnisciCompilerPipeline(CompilerBase):

--- a/rbc/omnisci_pipeline.py
+++ b/rbc/omnisci_pipeline.py
@@ -49,7 +49,7 @@ def free_omnisci_array(typingctx, ret):
 # Register this pass with the compiler framework, declare that it will not
 # mutate the control flow graph and that it is not an analysis_only pass (it
 # potentially mutates the IR).
-@register_pass(mutates_CFG=True, analysis_only=False)
+@register_pass(mutates_CFG=False, analysis_only=False)
 class FreeOmnisciArray(FunctionPass):
     _name = "free_omnisci_arrays"  # the common name for the pass
 
@@ -69,7 +69,7 @@ class FreeOmnisciArray(FunctionPass):
                     found = True
 
         if not found:
-            return False
+            return False  # we do not change the IR
 
         for blk in func_ir.blocks.values():
             loc = blk.loc
@@ -89,7 +89,7 @@ class FreeOmnisciArray(FunctionPass):
                 blk.insert_before_terminator(var)
                 break
 
-        return True
+        return True  # we changed the IR
 
 
 class OmnisciCompilerPipeline(CompilerBase):

--- a/rbc/omnisci_pipeline.py
+++ b/rbc/omnisci_pipeline.py
@@ -1,0 +1,65 @@
+from numba.core import ir, extending, ir_utils, cgutils
+from numba.core.compiler import CompilerBase, DefaultPassBuilder
+from numba.core.compiler_machinery import FunctionPass, register_pass
+from numba.core.untyped_passes import IRProcessing
+from numbers import Number
+from numba import njit, types
+
+@extending.intrinsic
+def teste(typingctx):
+    sig = types.void()
+
+    def codegen(context, builder, signature, args):
+        cgutils.printf(builder, "Teste!!\n")
+
+    return sig, codegen
+
+
+# Register this pass with the compiler framework, declare that it will not
+# mutate the control flow graph and that it is not an analysis_only pass (it
+# potentially mutates the IR).
+@register_pass(mutates_CFG=True, analysis_only=False)
+class FreeOmnisciArray(FunctionPass):
+    _name = "free_omnisci_arrays" # the common name for the pass
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    # implement method to do the work, "state" is the internal compiler
+    # state from the CompilerBase instance.
+    def run_pass(self, state):
+        func_ir = state.func_ir # get the FunctionIR object
+        mutated = True # used to record whether this pass mutates the IR
+        for blk in func_ir.blocks.values():
+            loc = blk.loc
+            scope = blk.scope
+            for inst in blk.find_insts(ir.Return):
+
+                value = ir.Global("teste", teste, loc)
+                target = ir.Var(scope, "load_teste", loc)
+                stmt = ir.Assign(value, target, loc)
+                blk.insert_before_terminator(stmt)
+
+                new_expr = ir.Expr.call(func=target, args=[],
+                                        kws=(), loc=loc)
+                lhs = ir.Var(blk.scope, "teste_var_lhs", blk.loc)
+                var = ir.Assign(new_expr, lhs, blk.loc)
+                blk.insert_before_terminator(var)
+                break
+
+        return mutated # return True if the IR was mutated, False if not.
+
+
+class OmnisciCompilerPipeline(CompilerBase): # custom compiler extends from CompilerBase
+
+    def define_pipelines(self):
+        # define a new set of pipelines (just one in this case) and for ease
+        # base it on an existing pipeline from the DefaultPassBuilder,
+        # namely the "nopython" pipeline
+        pm = DefaultPassBuilder.define_nopython_pipeline(self.state)
+        # Add the new pass to run after IRProcessing
+        pm.add_pass_after(FreeOmnisciArray, IRProcessing)
+        # finalize
+        pm.finalize()
+        # return as an iterable, any number of pipelines may be defined!
+        return [pm]

--- a/rbc/omnisci_pipeline.py
+++ b/rbc/omnisci_pipeline.py
@@ -38,13 +38,9 @@ def free_omnisci_array(typingctx, ret):
             ptr = builder.bitcast(ptr, int8_t.as_pointer())
             for ptr8 in buffers:
                 with builder.if_then(builder.icmp_signed('!=', ptr, ptr8)):
-                    cgutils.printf(builder, "[Free] Deleting ptr: %p\n", ptr8)
                     builder.call(free_fn, [ptr8])
-                with builder.if_then(builder.icmp_signed('==', ptr, ptr8)):
-                    cgutils.printf(builder, "[Free] Skipping ptr %p\n", ptr)
         else:
             for ptr8 in buffers:
-                cgutils.printf(builder, "[Free] Deleting ptr: %p\n", ptr8)
                 builder.call(free_fn, [ptr8])
 
         del builder_buffers[builder]

--- a/rbc/omnisci_pipeline.py
+++ b/rbc/omnisci_pipeline.py
@@ -2,12 +2,12 @@ from .utils import get_version
 from llvmlite import ir as llvm_ir
 from .omnisci_array import builder_buffers, ArrayPointer
 if get_version('numba') >= (0, 49):
-    from numba.core import ir, extending, cgutils, types
+    from numba.core import ir, extending, types
     from numba.core.compiler import CompilerBase, DefaultPassBuilder
     from numba.core.compiler_machinery import FunctionPass, register_pass
     from numba.core.untyped_passes import IRProcessing
 else:
-    from numba import ir, extending, cgutils, types
+    from numba import ir, extending, types
     from numba.compiler import CompilerBase, DefaultPassBuilder
     from numba.compiler_machinery import FunctionPass, register_pass
     from numba.untyped_passes import IRProcessing

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -90,7 +90,7 @@ def get_client_config(**config):
 
     conf_file = os.environ.get('OMNISCI_CLIENT_CONF', None)
     if conf_file is not None and not os.path.isfile(conf_file):
-        print(f'rbc.omnisci.get_client_config:'
+        print(f'rbc.omnisci.get_client_config:'  # noqa: F541
               ' OMNISCI_CLIENT_CONF={conf_file!r}'
               ' is not a file, ignoring.')
         conf_file = None

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -8,6 +8,7 @@ from .thrift.utils import resolve_includes
 from pymapd.cursor import make_row_results_set
 from pymapd._parsers import _extract_description  # , _bind_parameters
 from .omnisci_array import array_type_converter
+from .omnisci_pipeline import OmnisciCompilerPipeline
 from .targetinfo import TargetInfo
 from .irtools import compile_to_LLVM
 from .errors import ForbiddenNameError
@@ -472,7 +473,8 @@ class RemoteOmnisci(RemoteJIT):
                     signatures.append(sig)
                 functions_and_signatures.append((caller.func, signatures))
             llvm_module = compile_to_LLVM(functions_and_signatures,
-                                          target_info, self.debug)
+                                          target_info,
+                                          OmnisciCompilerPipeline, self.debug)
             assert llvm_module.triple == target_info.triple
             assert llvm_module.data_layout == target_info.datalayout
             device_ir_map[device] = str(llvm_module)

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -10,45 +10,45 @@ pytestmark = pytest.mark.skipif(not available_version, reason=reason)
 def omnisci():
     config = rbc_omnisci.get_client_config(debug=not True)
     m = rbc_omnisci.RemoteOmnisci(**config)
-    table_name = 'rbc_test_omnisci_array'
-    m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
-    sqltypes = ['FLOAT[]', 'DOUBLE[]',
-                'TINYINT[]', 'SMALLINT[]', 'INT[]', 'BIGINT[]',
-                'BOOLEAN[]']
-    # todo: TEXT ENCODING DICT, TEXT ENCODING NONE, TIMESTAMP, TIME,
-    # DATE, DECIMAL/NUMERIC, GEOMETRY: POINT, LINESTRING, POLYGON,
-    # MULTIPOLYGON, See
-    # https://www.omnisci.com/docs/latest/5_datatypes.html
-    colnames = ['f4', 'f8', 'i1', 'i2', 'i4', 'i8', 'b']
-    table_defn = ',\n'.join('%s %s' % (n, t)
-                            for t, n in zip(sqltypes, colnames))
-    m.sql_execute(
-        'CREATE TABLE IF NOT EXISTS {table_name} ({table_defn});'
-        .format(**locals()))
+    # table_name = 'rbc_test_omnisci_array'
+    # m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
+    # sqltypes = ['FLOAT[]', 'DOUBLE[]',
+    #             'TINYINT[]', 'SMALLINT[]', 'INT[]', 'BIGINT[]',
+    #             'BOOLEAN[]']
+    # # todo: TEXT ENCODING DICT, TEXT ENCODING NONE, TIMESTAMP, TIME,
+    # # DATE, DECIMAL/NUMERIC, GEOMETRY: POINT, LINESTRING, POLYGON,
+    # # MULTIPOLYGON, See
+    # # https://www.omnisci.com/docs/latest/5_datatypes.html
+    # colnames = ['f4', 'f8', 'i1', 'i2', 'i4', 'i8', 'b']
+    # table_defn = ',\n'.join('%s %s' % (n, t)
+    #                         for t, n in zip(sqltypes, colnames))
+    # m.sql_execute(
+    #     'CREATE TABLE IF NOT EXISTS {table_name} ({table_defn});'
+    #     .format(**locals()))
 
-    def row_value(row, col, colname):
-        if colname == 'b':
-            return 'ARRAY[%s]' % (', '.join(
-                ("'true'" if i % 2 == 0 else "'false'")
-                for i in range(-3, 3)))
-        if colname.startswith('f'):
-            return 'ARRAY[%s]' % (', '.join(
-                str(row * 10 + i + 0.5) for i in range(-3, 3)))
-        return 'ARRAY[%s]' % (', '.join(
-            str(row * 10 + i) for i in range(-3, 3)))
+    # def row_value(row, col, colname):
+    #     if colname == 'b':
+    #         return 'ARRAY[%s]' % (', '.join(
+    #             ("'true'" if i % 2 == 0 else "'false'")
+    #             for i in range(-3, 3)))
+    #     if colname.startswith('f'):
+    #         return 'ARRAY[%s]' % (', '.join(
+    #             str(row * 10 + i + 0.5) for i in range(-3, 3)))
+    #     return 'ARRAY[%s]' % (', '.join(
+    #         str(row * 10 + i) for i in range(-3, 3)))
 
-    rows = 5
-    for i in range(rows):
-        table_row = ', '.join(str(row_value(i, j, n))
-                              for j, n in enumerate(colnames))
-        m.sql_execute(
-            'INSERT INTO {table_name} VALUES ({table_row})'.format(**locals()))
-    m.table_name = table_name
+    # rows = 5
+    # for i in range(rows):
+    #     table_row = ', '.join(str(row_value(i, j, n))
+    #                           for j, n in enumerate(colnames))
+    #     m.sql_execute(
+    #         'INSERT INTO {table_name} VALUES ({table_row})'.format(**locals()))
+    # m.table_name = table_name
     yield m
-    try:
-        m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
-    except Exception as msg:
-        print('%s in deardown' % (type(msg)))
+    # try:
+    #     m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
+    # except Exception as msg:
+    #     print('%s in deardown' % (type(msg)))
 
 
 def _test_get_array_size_ir1(omnisci):

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -293,8 +293,6 @@ def test_array_constructor_len(omnisci):
         a = Array(size, types.int32)
         return len(a)
 
-    print(str(array_len))
-
     query = (
         'select array_len(30)'
         .format(**locals()))

--- a/rbc/tests/test_omnisci_udtf.py
+++ b/rbc/tests/test_omnisci_udtf.py
@@ -69,7 +69,7 @@ def test_simple(omnisci):
             print(i, r)
 
     def my_row_copier2(x,
-                       n_ptr: dict(sizer='kUserSpecifiedConstantParameter'),
+                       n_ptr: dict(sizer='kUserSpecifiedConstantParameter'),  # noqa: F821,E501
                        input_row_count_ptr, output_row_count, y):
         n = n_ptr[0]
         m = 5
@@ -103,7 +103,7 @@ def test_simple(omnisci):
     @omnisci('int32|table(double*|cursor, int32*|input, int64*, int64*,'
              ' double*|output)')
     def my_row_copier3(x,
-                       m_ptr: dict(sizer='kUserSpecifiedRowMultiplier'),
+                       m_ptr: dict(sizer='kUserSpecifiedRowMultiplier'),  # noqa: F821,E501
                        input_row_count_ptr, output_row_count, y):
         m = m_ptr[0]
         input_row_count = input_row_count_ptr[0]


### PR DESCRIPTION
This pull request tackles the problem fo memory management for omnisci arrays.

Missing
- [x] Only change the pipeline if `RemoteOmnisci` is used.
- [x] Do not attempt to free arrays if no array were declared in the function
- [x] Fix `mutate` logic
- [ ] Remove `cgutils.printf` calls or wrap then inside `if DEBUG_ENABLE` conditionals
