### PR TITLE
Implement cumsum, fixes issue 74

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -227,6 +227,9 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo,
         target_context = RemoteCPUContext(typing_context, target)
         # Bring over Array overloads (a hack):
         target_context._defns = target_desc.target_context._defns
+        # Fixes rbc issue 74:
+        target_desc.typing_context.target_info = target
+        target_desc.target_context.target_info = target
 
     typing_context.target_info = target
     target_context.target_info = target

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -297,6 +297,21 @@ def omnisci_array_mean(x):
         return impl
 
 
+@extending.overload(np.cumsum)
+def omnisci_np_cumsum(a):
+    if isinstance(a, ArrayPointer):
+        eltype = a.eltype
+
+        def impl(a):
+            sz = len(a)
+            out = Array(sz, eltype)
+            out[0] = a[0]
+            for i in range(1, sz):
+                out[i] = out[i-1] + a[i]
+            return out
+        return impl
+
+
 _array_type_match = re.compile(r'\A(.*)\s*[\[]\s*[\]]\Z').match
 
 

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -406,3 +406,22 @@ def test_array_constructor_is_null(omnisci):
     _, result = omnisci.sql_execute(query)
 
     assert list(result)[0] == (0,)
+
+
+def test_np_cumsum(omnisci):
+    omnisci.reset()
+
+    import numpy as np
+
+    @omnisci('int64[](int64[])')
+    def np_cumsum(a):
+        return np.cumsum(a)
+
+    query = (
+        'select i8, np_cumsum(i8) from {omnisci.table_name};'
+        .format(**locals()))
+    _, result = omnisci.sql_execute(query)
+
+    inp, out = list(result)[0]
+    expected = np.cumsum(inp)
+    assert np.isclose(expected, out, equal_nan=True).all()


### PR DESCRIPTION
While this PR fixes #74 , it is unclear why `compiler.compile_extra` ignores `typingctx` argument and uses `numba.targets.registry.cpu_target.typing_context` in the issue example.