### PR TITLE
Fix omnisci array methods tests

### DIFF
--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from rbc.omnisci_array import Array
 
 
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
@@ -15,108 +16,109 @@ def omnisci():
 
 
 ndarray_methods = [
-    ('fill', (5, 4), [4.0, 4.0, 4.0, 4.0, 4.0]),
-    ('max', (5, 4.0), 4.0),
-    ('max_empty', (0, ), -128),
-    ('max_initial', (5, 4.0, 30.0), 30.0),
-    ('mean', (5, 2.0), 2.0),
-    ('mean_empty_float', (0, ), np.nan),
-    ('mean_empty_int', (0, ), 0),
-    ('min', (5, 4.0), 4.0),
-    ('min_empty', (0, ), 32767),
-    ('min_initial', (5, 4.0, -3.0), -3.0),
-    ('sum', (5, 2.0), 10.0),
-    ('sum_initial', (5, 2.0, 2.0), 12.0),
-    ('prod', (5, 3.0), 243.0),
-    ('prod_initial', (5, 3.0, 2), 486.0),
+    ('fill', 'double[](int64, double)', (5, 4), [4.0, 4.0, 4.0, 4.0, 4.0]),
+    ('max', 'double(int64, double)', (5, 4.0), 4.0),
+    ('max_empty', 'int8(int32)', (0, ), -128),
+    ('max_initial', 'double(int64, double, double)', (5, 4.0, 30.0), 30.0),
+    ('mean', 'double(int64, double)', (5, 2.0), 2.0),
+    ('mean_empty_float', 'float64(int64)', (0, ), np.nan),
+    ('mean_empty_int', 'int32(int64)', (0, ), 0),
+    ('min', 'double(int64, double)', (5, 4.0), 4.0),
+    ('min_empty', 'int16(int64)', (0, ), 32767),
+    ('min_initial', 'double(int64, double, double)', (5, 4.0, -3.0), -3.0),
+    ('sum', 'double(int64, double)', (5, 2.0), 10.0),
+    ('sum_initial', 'double(int64, double, double)', (5, 2.0, 2.0), 12.0),
+    ('prod', 'double(int64, double)', (5, 3.0), 243.0),
+    ('prod_initial', 'double(int64, double, double)', (5, 3.0, 2), 486.0),
 ]
 
 
-@pytest.mark.parametrize("method, args, expected", ndarray_methods,
+def ndarray_fill(size, v):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a
+
+
+def ndarray_max(size, v):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.max()
+
+
+def ndarray_max_empty(size):
+    a = Array(size, 'int8')
+    return a.max()
+
+
+def ndarray_max_initial(size, v, initial):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.max(initial=initial)
+
+
+def ndarray_mean(size, v):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.mean()
+
+
+def ndarray_mean_empty_float(size):
+    a = Array(size, 'float64')
+    return a.mean()
+
+
+def ndarray_mean_empty_int(size):
+    a = Array(size, 'int32')
+    return a.mean()
+
+
+def ndarray_min(size, v):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.min()
+
+
+def ndarray_min_empty(size):
+    a = Array(size, 'int16')
+    return a.min()
+
+
+def ndarray_min_initial(size, v, initial):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.min(initial=initial)
+
+
+def ndarray_sum(size, v):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.sum()
+
+
+def ndarray_sum_initial(size, v, initial):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.sum(initial=initial)
+
+
+def ndarray_prod(size, v):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.prod()
+
+
+def ndarray_prod_initial(size, v, initial):
+    a = Array(size, 'double')
+    a.fill(v)
+    return a.prod(initial=initial)
+
+
+@pytest.mark.parametrize("method, signature, args, expected", ndarray_methods,
                          ids=[item[0] for item in ndarray_methods])
-def test_ndarray_methods(omnisci, method, args, expected):
+def test_ndarray_methods(omnisci, method, signature, args, expected):
     omnisci.reset()
-    from rbc.omnisci_array import Array
 
-    @omnisci('double[](int64, double)')
-    def ndarray_fill(size, v):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a
-
-    @omnisci('double(int64, double)')
-    def ndarray_max(size, v):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.max()
-
-    @omnisci('int8(int32)')
-    def ndarray_max_empty(size):
-        a = Array(size, 'int8')
-        return a.max()
-
-    @omnisci('double(int64, double, double)')
-    def ndarray_max_initial(size, v, initial):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.max(initial=initial)
-
-    @omnisci('double(int64, double)')
-    def ndarray_mean(size, v):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.mean()
-
-    @omnisci('float64(int64)')
-    def ndarray_mean_empty_float(size):
-        a = Array(size, 'float64')
-        return a.mean()
-
-    @omnisci('int32(int64)')
-    def ndarray_mean_empty_int(size):
-        a = Array(size, 'int32')
-        return a.mean()
-
-    @omnisci('double(int64, double)')
-    def ndarray_min(size, v):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.min()
-
-    @omnisci('int16(int64)')
-    def ndarray_min_empty(size):
-        a = Array(size, 'int16')
-        return a.min()
-
-    @omnisci('double(int64, double, double)')
-    def ndarray_min_initial(size, v, initial):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.min(initial=initial)
-
-    @omnisci('double(int64, double)')
-    def ndarray_sum(size, v):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.sum()
-
-    @omnisci('double(int64, double, double)')
-    def ndarray_sum_initial(size, v, initial):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.sum(initial=initial)
-
-    @omnisci('double(int64, double)')
-    def ndarray_prod(size, v):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.prod()
-
-    @omnisci('double(int64, double, double)')
-    def ndarray_prod_initial(size, v, initial):
-        a = Array(size, 'double')
-        a.fill(v)
-        return a.prod(initial=initial)
+    omnisci(signature)(eval('ndarray_{}'.format(method)))
 
     query = 'select ndarray_{method}'.format(**locals()) + \
             '(' + ', '.join(map(str, args)) + ')'


### PR DESCRIPTION
Fix https://github.com/xnd-project/rbc/issues/79

Edit: Add information about runtime speedup

Without this PR:
```
$ pytest -sv --durations=0 rbc/tests/test_omnisci_array_methods.py -x --disable-warnings
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.8.1, pytest-5.3.4, py-1.8.1, pluggy-0.13.1 -- /home/guilhermel/miniconda3/envs/rbc-dev/bin/python
cachedir: .pytest_cache
rootdir: /work/guilhermel/git/rbc
collecting ...  OmnisciDB version (5, 3, 0, 'dev-20200516-2d56e3d31b')
collected 14 items

rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[fill] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_empty] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_initial] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_float] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_int] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_empty] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_initial] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum_initial] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod_initial] PASSED

======================================================================================================== slowest test durations =========================================================================================================
2.27s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[fill]
1.76s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod_initial]
1.73s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_initial]
1.71s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum_initial]
1.70s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max]
1.69s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min]
1.65s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum]
1.64s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_initial]
1.63s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_float]
1.61s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_empty]
1.60s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_int]
1.59s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_empty]
1.59s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean]
1.53s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod]
0.03s setup    rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[fill]
```

With the changes introduced in this PR:

```
$ pytest -sv --durations=0 rbc/tests/test_omnisci_array_methods.py -x --disable-warnings
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.8.1, pytest-5.3.4, py-1.8.1, pluggy-0.13.1 -- /home/guilhermel/miniconda3/envs/rbc-dev/bin/python
cachedir: .pytest_cache
rootdir: /work/guilhermel/git/rbc
collecting ...  OmnisciDB version (5, 3, 0, 'dev-20200516-2d56e3d31b')
collected 14 items

rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[fill] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_empty] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_initial] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_float] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_int] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_empty] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_initial] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum_initial] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod] PASSED
rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod_initial] PASSED

======================================================================================================== slowest test durations =========================================================================================================
0.63s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[fill]
0.39s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_empty]
0.38s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_initial]
0.37s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum_initial]
0.31s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max]
0.31s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min_initial]
0.30s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[max_empty]
0.29s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[min]
0.28s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod_initial]
0.26s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_int]
0.26s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean]
0.26s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[prod]
0.25s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[sum]
0.18s call     rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[mean_empty_float]
0.03s setup    rbc/tests/test_omnisci_array_methods.py::test_ndarray_methods[fill]
```