### PR TITLE
Implement some operators.*

### DIFF
--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -292,12 +292,12 @@ def overload_binary_operator(op):
                         if not op(a[i], e[i]):
                             return False
                     return True
-            elif isinstance(e, types.Number): # e is Number
+            elif isinstance(e, types.Number):
                 def impl(a, e):
                     sz = len(a)
                     x = Array(sz, 'int8')
                     for i in range(sz):
-                        x[i] = typesystem.boolean8(op(a[i], e)) 
+                        x[i] = typesystem.boolean8(op(a[i], e))
                     return x
             return impl
 
@@ -307,6 +307,7 @@ def overload_binary_operator(op):
         return decorate(omnisci_operator_impl)
 
     return wrapper
+
 
 @overload_binary_operator(operator.eq)
 @overload_binary_operator(operator.ne)
@@ -392,7 +393,6 @@ def omnisci_array_setitem_(typingctx, data, index, value):
 def omnisci_array_setitem(a, i, v):
     if isinstance(a, ArrayPointer):
         return lambda a, i, v: omnisci_array_setitem_(a, i, v)
-
 
 
 _array_type_match = re.compile(r'\A(.*)\s*[\[]\s*[\]]\Z').match

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -420,6 +420,7 @@ def omnisci_array_countOf(a, b):
             return cnt
         return impl_countOf
 
+
 @extending.lower_builtin(operator.is_, ArrayPointer, ArrayPointer)
 def _omnisci_array_is(context, builder, sig, args):
     """Implements `a is b` operation

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -319,7 +319,7 @@ def omnisci_binary_cmp_operator_fn(a, e):
     pass
 
 
-def overload_binary_op(op):
+def overload_binary_op(op, inplace=False):
 
     def omnisci_operator_impl(a, b):
         if isinstance(a, ArrayPointer) and isinstance(b, ArrayPointer):
@@ -328,7 +328,12 @@ def overload_binary_op(op):
             def impl(a, b):
                 # XXX: raise exception if len(a) != len(b)
                 sz = len(a)
-                x = Array(sz, nb_dtype)
+
+                if inplace:
+                    x = a
+                else:
+                    x = Array(sz, nb_dtype)
+
                 for i in range(sz):
                     x[i] = nb_dtype(op(a[i], b[i]))
                 return x
@@ -354,6 +359,18 @@ def overload_binary_op(op):
 @overload_binary_op(operator.sub)
 @overload_binary_op(operator.truediv)
 @overload_binary_op(operator.xor)
+@overload_binary_op(operator.iadd, inplace=True)
+@overload_binary_op(operator.iand, inplace=True)
+@overload_binary_op(operator.ifloordiv, inplace=True)
+@overload_binary_op(operator.ilshift, inplace=True)
+@overload_binary_op(operator.imod, inplace=True)
+@overload_binary_op(operator.imul, inplace=True)
+@overload_binary_op(operator.ior, inplace=True)
+@overload_binary_op(operator.ipow, inplace=True)
+@overload_binary_op(operator.irshift, inplace=True)
+@overload_binary_op(operator.isub, inplace=True)
+@overload_binary_op(operator.itruediv, inplace=True)
+@overload_binary_op(operator.ixor, inplace=True)
 def omnisci_binary_operator_fn(a, b):
     pass
 

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -182,6 +182,17 @@ def omnisci_array_setitem(a, i, v):
         return lambda a, i, v: omnisci_array_setitem_(a, i, v)
 
 
+@extending.overload(operator.ne)
+def omnisci_array_ne(a, e):
+    if isinstance(a, ArrayPointer):
+        def impl(a, e):
+            x = Array(len(a), typesystem.boolean8)
+            for i in range(len(a)):
+                x[i] = typesystem.boolean8(operator.ne(a[i], e))
+            return x
+        return impl
+
+
 def get_type_limits(eltype):
     np_dtype = numpy_support.as_dtype(eltype)
     if isinstance(eltype, types.Integer):

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -375,6 +375,36 @@ def omnisci_binary_operator_fn(a, b):
     pass
 
 
+def overload_unary_op(op):
+
+    def omnisci_operator_impl(a):
+        if isinstance(a, ArrayPointer):
+            nb_dtype = a.eltype
+
+            def impl(a):
+                sz = len(a)
+                x = Array(sz, nb_dtype)
+                for i in range(sz):
+                    x[i] = nb_dtype(op(a[i]))
+                return x
+            return impl
+
+    decorate = extending.overload(op)
+
+    def wrapper(overload_func):
+        return decorate(omnisci_operator_impl)
+
+    return wrapper
+
+
+@overload_unary_op(abs)
+@overload_unary_op(operator.abs)
+@overload_unary_op(operator.neg)
+@overload_unary_op(operator.pos)
+def omnisci_unary_op(a):
+    pass
+
+
 @extending.lower_builtin(operator.is_, ArrayPointer, ArrayPointer)
 def _omnisci_array_is(context, builder, sig, args):
     """Implements `a is b` operation

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -185,6 +185,8 @@ def omnisci_array_setitem(a, i, v):
 
 @extending.overload(np.invert)
 def omnisci_np_invert(a):
+    """Implements `np.invert(expr)` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a):
             sz = len(a)
@@ -196,6 +198,8 @@ def omnisci_np_invert(a):
 
 @extending.overload(operator.eq)
 def omnisci_array_eq(a, e):
+    """Implements `a == e` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             sz = len(a)
@@ -208,6 +212,8 @@ def omnisci_array_eq(a, e):
 
 @extending.overload(operator.ne)
 def omnisci_array_ne(a, e):
+    """Implements `a != e` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             return np.invert(a == e)
@@ -216,6 +222,8 @@ def omnisci_array_ne(a, e):
 
 @extending.overload(operator.lt)
 def omnisci_array_lt(a, e):
+    """Implements `a < e` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             sz = len(a)
@@ -228,6 +236,8 @@ def omnisci_array_lt(a, e):
 
 @extending.overload(operator.le)
 def omnisci_array_le(a, e):
+    """Implements `a <= e` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             sz = len(a)
@@ -240,6 +250,8 @@ def omnisci_array_le(a, e):
 
 @extending.overload(operator.gt)
 def omnisci_array_gt(a, e):
+    """Implements `a > e` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             return np.invert(a <= e)
@@ -248,6 +260,8 @@ def omnisci_array_gt(a, e):
 
 @extending.overload(operator.ge)
 def omnisci_array_ge(a, e):
+    """Implements `a >= e` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             return np.invert(a < e)
@@ -256,18 +270,24 @@ def omnisci_array_ge(a, e):
 
 @extending.lower_builtin(operator.is_, ArrayPointer, ArrayPointer)
 def _omnisci_array_is(context, builder, sig, args):
+    """Implements `a is b` operation
+    """
     [a, b] = args
     return builder.icmp_signed('==', a, b)
 
 
 @extending.lower_builtin(operator.is_not, ArrayPointer, ArrayPointer)
 def _omnisci_array_is_not(context, builder, sig, args):
+    """Implements `a is not b` operation
+    """
     [a, b] = args
     return builder.icmp_signed('!=', a, b)
 
 
 @extending.overload(operator.contains)
 def omnisci_array_contains(a, e):
+    """Implements `e in a` operation
+    """
     if isinstance(a, ArrayPointer):
         def impl(a, e):
             sz = len(a)

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -405,6 +405,21 @@ def omnisci_unary_op(a):
     pass
 
 
+@extending.overload(operator.countOf)
+def omnisci_array_countOf(a, b):
+    """
+    Return the number of occurrences of b in a
+    """
+    if isinstance(a, ArrayPointer) and a.eltype == b:
+        def impl_countOf(a, b):
+            sz = len(a)
+            cnt = 0
+            for i in range(sz):
+                if a[i] == b:
+                    cnt += 1
+            return cnt
+        return impl_countOf
+
 @extending.lower_builtin(operator.is_, ArrayPointer, ArrayPointer)
 def _omnisci_array_is(context, builder, sig, args):
     """Implements `a is b` operation

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -280,7 +280,7 @@ def omnisci_np_cumsum(a):
         return impl
 
 
-def overload_binary_operator(op):
+def overload_binary_cmp_op(op):
 
     def omnisci_operator_impl(a, e):
         if isinstance(a, ArrayPointer):
@@ -309,13 +309,52 @@ def overload_binary_operator(op):
     return wrapper
 
 
-@overload_binary_operator(operator.eq)
-@overload_binary_operator(operator.ne)
-@overload_binary_operator(operator.lt)
-@overload_binary_operator(operator.le)
-@overload_binary_operator(operator.gt)
-@overload_binary_operator(operator.ge)
-def omnisci_binary_operator_fn(a, e):
+@overload_binary_cmp_op(operator.eq)
+@overload_binary_cmp_op(operator.ne)
+@overload_binary_cmp_op(operator.lt)
+@overload_binary_cmp_op(operator.le)
+@overload_binary_cmp_op(operator.gt)
+@overload_binary_cmp_op(operator.ge)
+def omnisci_binary_cmp_operator_fn(a, e):
+    pass
+
+
+def overload_binary_op(op):
+
+    def omnisci_operator_impl(a, b):
+        if isinstance(a, ArrayPointer) and isinstance(b, ArrayPointer):
+            nb_dtype = a.eltype
+
+            def impl(a, b):
+                # XXX: raise exception if len(a) != len(b)
+                sz = len(a)
+                x = Array(sz, nb_dtype)
+                for i in range(sz):
+                    x[i] = nb_dtype(op(a[i], b[i]))
+                return x
+            return impl
+
+    decorate = extending.overload(op)
+
+    def wrapper(overload_func):
+        return decorate(omnisci_operator_impl)
+
+    return wrapper
+
+
+@overload_binary_op(operator.add)
+@overload_binary_op(operator.and_)
+@overload_binary_op(operator.floordiv)
+@overload_binary_op(operator.lshift)
+@overload_binary_op(operator.mod)
+@overload_binary_op(operator.mul)
+@overload_binary_op(operator.or_)
+@overload_binary_op(operator.pow)
+@overload_binary_op(operator.rshift)
+@overload_binary_op(operator.sub)
+@overload_binary_op(operator.truediv)
+@overload_binary_op(operator.xor)
+def omnisci_binary_operator_fn(a, b):
     pass
 
 

--- a/rbc/omnisci_array.py
+++ b/rbc/omnisci_array.py
@@ -266,13 +266,6 @@ def _omnisci_array_is_not(context, builder, sig, args):
     return builder.icmp_signed('!=', a, b)
 
 
-@extending.overload(operator.is_)
-def omnisci_array_is(a, b):
-    breakpoint()
-    if isinstance(a, ArrayPointer) and isinstance(b, ArrayPointer):
-        return lambda a, b: _omnisci_array_is(a, b)
-
-
 @extending.overload(operator.contains)
 def omnisci_array_contains(a, e):
     if isinstance(a, ArrayPointer):

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -425,23 +425,3 @@ def test_np_cumsum(omnisci):
     inp, out = list(result)[0]
     expected = np.cumsum(inp)
     assert np.isclose(expected, out, equal_nan=True).all()
-
-
-def test_np_operator_ne(omnisci):
-    omnisci.reset()
-
-    import numpy as np
-
-    @omnisci('int64[](int64[])')
-    def np_cumsum(a):
-        x = a != 3
-        return np.cumsum(a)
-
-    query = (
-        'select i8, np_cumsum(i8) from {omnisci.table_name};'
-        .format(**locals()))
-    _, result = omnisci.sql_execute(query)
-
-    inp, out = list(result)[0]
-    expected = np.cumsum(inp)
-    assert np.isclose(expected, out, equal_nan=True).all()

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -426,3 +426,23 @@ def test_np_cumsum(omnisci):
     inp, out = list(result)[0]
     expected = np.cumsum(inp)
     assert np.isclose(expected, out, equal_nan=True).all()
+
+
+def test_np_operator_ne(omnisci):
+    omnisci.reset()
+
+    import numpy as np
+
+    @omnisci('int64[](int64[])')
+    def np_cumsum(a):
+        x = a != 3
+        return np.cumsum(a)
+
+    query = (
+        'select i8, np_cumsum(i8) from {omnisci.table_name};'
+        .format(**locals()))
+    _, result = omnisci.sql_execute(query)
+
+    inp, out = list(result)[0]
+    expected = np.cumsum(inp)
+    assert np.isclose(expected, out, equal_nan=True).all()

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -486,6 +486,12 @@ def operator_is_not2(size, v):
 @pytest.mark.parametrize("suffix, signature, args, expected", operator_methods,
                          ids=[item[0] for item in operator_methods])
 def test_array_operators(omnisci, suffix, signature, args, expected):
+
+    if omnisci.has_cuda and suffix in ['countOf', 'in', 'not_in']:
+        # https://github.com/xnd-project/rbc/issues/107
+        pytest.skip(f'operator_{suffix}: crashes CUDA enabled omniscidb server'
+                    ' [rbc issue 107]')
+
     omnisci.reset()
 
     omnisci(signature)(eval('operator_{}'.format(suffix)))

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -23,6 +23,12 @@ operator_methods = [
     ('le', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 1, 0, 0]),
     ('gt', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 0, 1, 1]),
     ('ge', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 1, 1]),
+    ('eq_array', 'bool(int64, int32)', (6, 3), True),
+    ('ne_array', 'bool(int64, int32)', (6, 3), False),
+    ('lt_array', 'bool(int64, int32)', (6, 3), False),
+    ('le_array', 'bool(int64, int32)', (6, 3), True),
+    ('gt_array', 'bool(int64, int32)', (6, 3), False),
+    ('ge_array', 'bool(int64, int32)', (6, 3), True),
     ('in', 'int8(int64, int32)', (6, 3), True),
     ('not_in', 'int8(int64, int32)', (6, 3), False),
     ('is', 'int8(int64, int32)', (6, 3), True),
@@ -38,11 +44,25 @@ def operator_eq(size, v):
     return a == v
 
 
+def operator_eq_array(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a == a
+
+
 def operator_ne(size, v):
     a = Array(size, 'int32')
     for i in range(size):
         a[i] = nb_types.int32(i)
     return a != v
+
+
+def operator_ne_array(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a != a
 
 
 def operator_lt(size, v):
@@ -52,11 +72,25 @@ def operator_lt(size, v):
     return a < v
 
 
+def operator_lt_array(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a < a
+
+
 def operator_le(size, v):
     a = Array(size, 'int32')
     for i in range(size):
         a[i] = nb_types.int32(i)
     return a <= v
+
+
+def operator_le_array(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a <= a
 
 
 def operator_gt(size, v):
@@ -66,11 +100,25 @@ def operator_gt(size, v):
     return a > v
 
 
+def operator_gt_array(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a > a
+
+
 def operator_ge(size, v):
     a = Array(size, 'int32')
     for i in range(size):
         a[i] = nb_types.int32(i)
     return a >= v
+
+
+def operator_ge_array(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a >= a
 
 
 def operator_in(size, v):
@@ -120,6 +168,8 @@ def test_array_operators(omnisci, suffix, signature, args, expected):
     out = list(result)[0]
 
     if suffix in ['in', 'not_in']:
+        assert (expected == out[0]), 'operator_' + suffix
+    elif '_array' in suffix:
         assert (expected == out[0]), 'operator_' + suffix
     else:
         assert np.array_equal(expected, out[0]), 'operator_' + suffix

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -21,6 +21,8 @@ operator_methods = [
     ('abs', 'int32[](int64)', (6,), np.arange(6)),
     ('add', 'int32[](int64)', (6,), np.full(6, 5)),
     ('and_', 'int32[](int64)', (6,), [0, 0, 2, 2, 0, 0]),
+    ('countOf', 'int64(int64, int64, int64)', (6, 3, 4), 0),
+    ('countOf', 'int64(int64, int64, int64)', (6, 3, 3), 6),
     ('eq', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 0, 0]),
     ('eq_array', 'bool(int64, int32)', (6, 3), True),
     ('floordiv', 'int32[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
@@ -67,6 +69,13 @@ operator_methods = [
     ('truediv2', 'double[](int64)', (6,), [3.3333333333333335, 2.75, 2.4, 2.1666666666666665, 2.0, 1.875]),  # noqa: E501
     ('xor', 'int32[](int64)', (6,), [5, 5, 1, 1, 5, 5]),
 ]
+
+
+def operator_countOf(size, fill_value, b):
+    a = Array(size, 'int64')
+    for i in range(size):
+        a[i] = fill_value
+    return operator.countOf(a, b)
 
 
 def operator_neg(size):

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -1,0 +1,125 @@
+import pytest
+import numpy as np
+from rbc.omnisci_array import Array
+from numba import types as nb_types
+
+
+rbc_omnisci = pytest.importorskip('rbc.omniscidb')
+available_version, reason = rbc_omnisci.is_available()
+pytestmark = pytest.mark.skipif(not available_version, reason=reason)
+
+
+@pytest.fixture(scope='module')
+def omnisci():
+    config = rbc_omnisci.get_client_config(debug=not True)
+    m = rbc_omnisci.RemoteOmnisci(**config)
+    yield m
+
+
+operator_methods = [
+    ('eq', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 0, 0]),
+    ('ne', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 1, 1]),
+    ('lt', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 0, 0]),
+    ('le', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 1, 0, 0]),
+    ('gt', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 0, 1, 1]),
+    ('ge', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 1, 1]),
+    ('in', 'int8(int64, int32)', (6, 3), True),
+    ('not_in', 'int8(int64, int32)', (6, 3), False),
+    ('is', 'int8(int64, int32)', (6, 3), True),
+    ('is_not', 'int8(int64, int32)', (6, 3), False),
+    ('is_not2', 'int8(int64, int32)', (6, 3), True),
+]
+
+
+def operator_eq(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a == v
+
+
+def operator_ne(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a != v
+
+
+def operator_lt(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a < v
+
+
+def operator_le(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a <= v
+
+
+def operator_gt(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a > v
+
+
+def operator_ge(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return a >= v
+
+
+def operator_in(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return v in a
+
+
+def operator_not_in(size, v):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return v not in a
+
+
+def operator_is(size, v):
+    a = Array(size, 'int32')
+    a.fill(v)
+    return a is a
+
+
+def operator_is_not(size, v):
+    a = Array(size, 'int32')
+    a.fill(v)
+    return a is not a
+
+
+def operator_is_not2(size, v):
+    a = Array(size, 'int32')
+    a.fill(v)
+    b = Array(size, 'int32')
+    b.fill(v)
+    return a is not b
+
+
+@pytest.mark.parametrize("suffix, signature, args, expected", operator_methods,
+                         ids=[item[0] for item in operator_methods])
+def test_array_operators(omnisci, suffix, signature, args, expected):
+    omnisci.reset()
+
+    omnisci(signature)(eval('operator_{}'.format(suffix)))
+
+    query = 'select operator_{suffix}'.format(**locals()) + \
+            '(' + ', '.join(map(str, args)) + ')'
+    _, result = omnisci.sql_execute(query)
+    out = list(result)[0]
+
+    if suffix in ['in', 'not_in']:
+        assert (expected == out[0]), 'operator_' + suffix
+    else:
+        assert np.array_equal(expected, out[0]), 'operator_' + suffix

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -28,6 +28,19 @@ operator_methods = [
     ('ge_array', 'bool(int64, int32)', (6, 3), True),
     ('gt', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 0, 1, 1]),
     ('gt_array', 'bool(int64, int32)', (6, 3), False),
+    ('iadd', 'int32[](int64)', (6,), [1, 2, 3, 4, 5, 6]),
+    ('iand', 'int32[](int64)', (6,), [0, 0, 2, 2, 0, 0]),
+    ('ifloordiv', 'int32[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
+    ('ifloordiv2', 'double[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
+    ('ilshift', 'int32[](int64)', (6,), [0, 16, 16, 12, 8, 5]),
+    ('imul', 'int32[](int64)', (6,), [0, 4, 6, 6, 4, 0]),
+    ('ior', 'int32[](int64)', (6,), [5, 5, 3, 3, 5, 5]),
+    ('isub', 'int32[](int64)', (6,), [-5, -3, -1, 1, 3, 5]),
+    ('ipow', 'int32[](int64)', (6,), [1, 32, 81, 64, 25, 6]),
+    ('irshift', 'int32[](int64)', (6,), [0, 0, 0, 0, 2, 5]),
+    ('itruediv', 'int32[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
+    ('itruediv2', 'double[](int64)', (6,), [3.3333333333333335, 2.75, 2.4, 2.1666666666666665, 2.0, 1.875]),  # noqa: E501
+    ('ixor', 'int32[](int64)', (6,), [5, 5, 1, 1, 5, 5]),
     ('in', 'int8(int64, int32)', (6, 3), True),
     ('is', 'int8(int64, int32)', (6, 3), True),
     ('is_not', 'int8(int64, int32)', (6, 3), False),
@@ -38,6 +51,8 @@ operator_methods = [
     ('lt', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 0, 0]),
     ('lt_array', 'bool(int64, int32)', (6, 3), False),
     ('mul', 'int32[](int64)', (6,), [0, 4, 6, 6, 4, 0]),
+    ('mod', 'int32[](int64)', (6,), [0, 4, 1, 5, 2, 6]),
+    ('imod', 'int32[](int64)', (6,), [0, 4, 1, 5, 2, 6]),
     ('ne', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 1, 1]),
     ('ne_array', 'bool(int64, int32)', (6, 3), False),
     ('not_in', 'int8(int64, int32)', (6, 3), False),
@@ -60,6 +75,16 @@ def operator_rshift(size):
     return operator.rshift(a, b)
 
 
+def operator_irshift(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.irshift(a, b)
+    return a
+
+
 def operator_lshift(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
@@ -67,6 +92,16 @@ def operator_lshift(size):
         a[i] = nb_types.int32(i)
         b[i] = nb_types.int32(size-i-1)
     return operator.lshift(a, b)
+
+
+def operator_ilshift(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.ilshift(a, b)
+    return a
 
 
 def operator_floordiv(size):
@@ -78,6 +113,16 @@ def operator_floordiv(size):
     return operator.floordiv(a, b)
 
 
+def operator_ifloordiv(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i+10)
+        b[i] = nb_types.int32(i+3)
+    operator.ifloordiv(a, b)
+    return a
+
+
 def operator_floordiv2(size):
     a = Array(size, 'double')
     b = Array(size, 'double')
@@ -85,6 +130,16 @@ def operator_floordiv2(size):
         a[i] = nb_types.double(i+10)
         b[i] = nb_types.double(i+3)
     return operator.floordiv(a, b)
+
+
+def operator_ifloordiv2(size):
+    a = Array(size, 'double')
+    b = Array(size, 'double')
+    for i in range(size):
+        a[i] = nb_types.double(i+10)
+        b[i] = nb_types.double(i+3)
+    operator.ifloordiv(a, b)
+    return a
 
 
 def operator_truediv(size):
@@ -96,6 +151,16 @@ def operator_truediv(size):
     return operator.truediv(a, b)
 
 
+def operator_itruediv(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i+10)
+        b[i] = nb_types.int32(i+3)
+    operator.itruediv(a, b)
+    return a
+
+
 def operator_truediv2(size):
     a = Array(size, 'double')
     b = Array(size, 'double')
@@ -103,6 +168,16 @@ def operator_truediv2(size):
         a[i] = nb_types.double(i+10)
         b[i] = nb_types.double(i+3)
     return operator.truediv(a, b)
+
+
+def operator_itruediv2(size):
+    a = Array(size, 'double')
+    b = Array(size, 'double')
+    for i in range(size):
+        a[i] = nb_types.double(i+10)
+        b[i] = nb_types.double(i+3)
+    operator.itruediv(a, b)
+    return a
 
 
 def operator_pow(size):
@@ -114,6 +189,16 @@ def operator_pow(size):
     return operator.pow(a, b)
 
 
+def operator_ipow(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i+1)
+        b[i] = nb_types.int32(size-i)
+    operator.ipow(a, b)
+    return a
+
+
 def operator_mul(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
@@ -121,6 +206,35 @@ def operator_mul(size):
         a[i] = nb_types.int32(i)
         b[i] = nb_types.int32(size-i-1)
     return operator.mul(a, b)
+
+
+def operator_imul(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.imul(a, b)
+    return a
+
+
+def operator_mod(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i * 123)
+        b[i] = nb_types.int32(7)
+    return operator.mod(a, b)
+
+
+def operator_imod(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i * 123)
+        b[i] = nb_types.int32(7)
+    operator.imod(a, b)
+    return a
 
 
 def operator_sub(size):
@@ -132,6 +246,16 @@ def operator_sub(size):
     return operator.sub(a, b)
 
 
+def operator_isub(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.isub(a, b)
+    return a
+
+
 def operator_add(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
@@ -139,6 +263,16 @@ def operator_add(size):
         a[i] = nb_types.int32(i)
         b[i] = nb_types.int32(size-i-1)
     return operator.add(a, b)
+
+
+def operator_iadd(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(1)
+    operator.iadd(a, b)
+    return a
 
 
 def operator_xor(size):
@@ -150,6 +284,16 @@ def operator_xor(size):
     return operator.xor(a, b)
 
 
+def operator_ixor(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.ixor(a, b)
+    return a
+
+
 def operator_or_(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
@@ -159,6 +303,16 @@ def operator_or_(size):
     return operator.or_(a, b)
 
 
+def operator_ior(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.ior(a, b)
+    return a
+
+
 def operator_and_(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
@@ -166,6 +320,16 @@ def operator_and_(size):
         a[i] = nb_types.int32(i)
         b[i] = nb_types.int32(size-i-1)
     return operator.and_(a, b)
+
+
+def operator_iand(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    operator.iand(a, b)
+    return a
 
 
 def operator_eq(size, v):

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -20,7 +20,7 @@ def omnisci():
 operator_methods = [
     ('abs', 'int32[](int64)', (6,), np.arange(6)),
     ('add', 'int32[](int64)', (6,), np.full(6, 5)),
-    ('and_', 'int32[](int64)', (6,), [0, 0, 2, 2, 0, 0]),
+    ('and_bw', 'int32[](int64)', (6,), [0, 0, 2, 2, 0, 0]),
     ('countOf', 'int64(int64, int64, int64)', (6, 3, 4), 0),
     ('countOf', 'int64(int64, int64, int64)', (6, 3, 3), 6),
     ('eq', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 0, 0]),
@@ -60,7 +60,7 @@ operator_methods = [
     ('neg', 'int32[](int64)', (6,), [0, -1, -2, -3, -4, -5]),
     ('ne_array', 'bool(int64, int32)', (6, 3), False),
     ('not_in', 'int8(int64, int32)', (6, 3), False),
-    ('or_', 'int32[](int64)', (6,), [5, 5, 3, 3, 5, 5]),
+    ('or_bw', 'int32[](int64)', (6,), [5, 5, 3, 3, 5, 5]),
     ('pos', 'int32[](int64)', (6,), [0, -1, -2, -3, -4, -5]),
     ('pow', 'int32[](int64)', (6,), [1, 32, 81, 64, 25, 6]),
     ('rshift', 'int32[](int64)', (6,), [0, 0, 0, 0, 2, 5]),
@@ -327,7 +327,7 @@ def operator_ixor(size):
     return a
 
 
-def operator_or_(size):
+def operator_or_bw(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
     for i in range(size):
@@ -346,7 +346,7 @@ def operator_ior(size):
     return a
 
 
-def operator_and_(size):
+def operator_and_bw(size):
     a = Array(size, 'int32')
     b = Array(size, 'int32')
     for i in range(size):

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -18,6 +18,7 @@ def omnisci():
 
 
 operator_methods = [
+    ('abs', 'int32[](int64)', (6,), np.arange(6)),
     ('add', 'int32[](int64)', (6,), np.full(6, 5)),
     ('and_', 'int32[](int64)', (6,), [0, 0, 2, 2, 0, 0]),
     ('eq', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 0, 0]),
@@ -40,6 +41,7 @@ operator_methods = [
     ('irshift', 'int32[](int64)', (6,), [0, 0, 0, 0, 2, 5]),
     ('itruediv', 'int32[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
     ('itruediv2', 'double[](int64)', (6,), [3.3333333333333335, 2.75, 2.4, 2.1666666666666665, 2.0, 1.875]),  # noqa: E501
+    ('imod', 'int32[](int64)', (6,), [0, 4, 1, 5, 2, 6]),
     ('ixor', 'int32[](int64)', (6,), [5, 5, 1, 1, 5, 5]),
     ('in', 'int8(int64, int32)', (6, 3), True),
     ('is', 'int8(int64, int32)', (6, 3), True),
@@ -52,11 +54,12 @@ operator_methods = [
     ('lt_array', 'bool(int64, int32)', (6, 3), False),
     ('mul', 'int32[](int64)', (6,), [0, 4, 6, 6, 4, 0]),
     ('mod', 'int32[](int64)', (6,), [0, 4, 1, 5, 2, 6]),
-    ('imod', 'int32[](int64)', (6,), [0, 4, 1, 5, 2, 6]),
     ('ne', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 1, 1]),
+    ('neg', 'int32[](int64)', (6,), [0, -1, -2, -3, -4, -5]),
     ('ne_array', 'bool(int64, int32)', (6, 3), False),
     ('not_in', 'int8(int64, int32)', (6, 3), False),
     ('or_', 'int32[](int64)', (6,), [5, 5, 3, 3, 5, 5]),
+    ('pos', 'int32[](int64)', (6,), [0, -1, -2, -3, -4, -5]),
     ('pow', 'int32[](int64)', (6,), [1, 32, 81, 64, 25, 6]),
     ('rshift', 'int32[](int64)', (6,), [0, 0, 0, 0, 2, 5]),
     ('sub', 'int32[](int64)', (6,), [-5, -3, -1, 1, 3, 5]),
@@ -64,6 +67,27 @@ operator_methods = [
     ('truediv2', 'double[](int64)', (6,), [3.3333333333333335, 2.75, 2.4, 2.1666666666666665, 2.0, 1.875]),  # noqa: E501
     ('xor', 'int32[](int64)', (6,), [5, 5, 1, 1, 5, 5]),
 ]
+
+
+def operator_neg(size):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+    return operator.neg(a)
+
+
+def operator_abs(size):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(-i)
+    return abs(a)
+
+
+def operator_pos(size):
+    a = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(-i)
+    return operator.pos(a)
 
 
 def operator_rshift(size):

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from rbc.omnisci_array import Array
 from numba import types as nb_types
+import operator
 
 
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
@@ -17,24 +18,154 @@ def omnisci():
 
 
 operator_methods = [
+    ('add', 'int32[](int64)', (6,), np.full(6, 5)),
+    ('and_', 'int32[](int64)', (6,), [0, 0, 2, 2, 0, 0]),
     ('eq', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 0, 0]),
-    ('ne', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 1, 1]),
-    ('lt', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 0, 0]),
-    ('le', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 1, 0, 0]),
-    ('gt', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 0, 1, 1]),
-    ('ge', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 1, 1]),
     ('eq_array', 'bool(int64, int32)', (6, 3), True),
-    ('ne_array', 'bool(int64, int32)', (6, 3), False),
-    ('lt_array', 'bool(int64, int32)', (6, 3), False),
-    ('le_array', 'bool(int64, int32)', (6, 3), True),
-    ('gt_array', 'bool(int64, int32)', (6, 3), False),
+    ('floordiv', 'int32[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
+    ('floordiv2', 'double[](int64)', (6,), [3.0, 2.0, 2.0, 2.0, 2.0, 1.0]),
+    ('ge', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 1, 1, 1]),
     ('ge_array', 'bool(int64, int32)', (6, 3), True),
+    ('gt', 'int8[](int64, int32)', (6, 3), [0, 0, 0, 0, 1, 1]),
+    ('gt_array', 'bool(int64, int32)', (6, 3), False),
     ('in', 'int8(int64, int32)', (6, 3), True),
-    ('not_in', 'int8(int64, int32)', (6, 3), False),
     ('is', 'int8(int64, int32)', (6, 3), True),
     ('is_not', 'int8(int64, int32)', (6, 3), False),
     ('is_not2', 'int8(int64, int32)', (6, 3), True),
+    ('le', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 1, 0, 0]),
+    ('le_array', 'bool(int64, int32)', (6, 3), True),
+    ('lshift', 'int32[](int64)', (6,), [0, 16, 16, 12, 8, 5]),
+    ('lt', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 0, 0]),
+    ('lt_array', 'bool(int64, int32)', (6, 3), False),
+    ('mul', 'int32[](int64)', (6,), [0, 4, 6, 6, 4, 0]),
+    ('ne', 'int8[](int64, int32)', (6, 3), [1, 1, 1, 0, 1, 1]),
+    ('ne_array', 'bool(int64, int32)', (6, 3), False),
+    ('not_in', 'int8(int64, int32)', (6, 3), False),
+    ('or_', 'int32[](int64)', (6,), [5, 5, 3, 3, 5, 5]),
+    ('pow', 'int32[](int64)', (6,), [1, 32, 81, 64, 25, 6]),
+    ('rshift', 'int32[](int64)', (6,), [0, 0, 0, 0, 2, 5]),
+    ('sub', 'int32[](int64)', (6,), [-5, -3, -1, 1, 3, 5]),
+    ('truediv', 'int32[](int64)', (6,), [3, 2, 2, 2, 2, 1]),
+    ('truediv2', 'double[](int64)', (6,), [3.3333333333333335, 2.75, 2.4, 2.1666666666666665, 2.0, 1.875]),  # noqa: E501
+    ('xor', 'int32[](int64)', (6,), [5, 5, 1, 1, 5, 5]),
 ]
+
+
+def operator_rshift(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.rshift(a, b)
+
+
+def operator_lshift(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.lshift(a, b)
+
+
+def operator_floordiv(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i+10)
+        b[i] = nb_types.int32(i+3)
+    return operator.floordiv(a, b)
+
+
+def operator_floordiv2(size):
+    a = Array(size, 'double')
+    b = Array(size, 'double')
+    for i in range(size):
+        a[i] = nb_types.double(i+10)
+        b[i] = nb_types.double(i+3)
+    return operator.floordiv(a, b)
+
+
+def operator_truediv(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i+10)
+        b[i] = nb_types.int32(i+3)
+    return operator.truediv(a, b)
+
+
+def operator_truediv2(size):
+    a = Array(size, 'double')
+    b = Array(size, 'double')
+    for i in range(size):
+        a[i] = nb_types.double(i+10)
+        b[i] = nb_types.double(i+3)
+    return operator.truediv(a, b)
+
+
+def operator_pow(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i+1)
+        b[i] = nb_types.int32(size-i)
+    return operator.pow(a, b)
+
+
+def operator_mul(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.mul(a, b)
+
+
+def operator_sub(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.sub(a, b)
+
+
+def operator_add(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.add(a, b)
+
+
+def operator_xor(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.xor(a, b)
+
+
+def operator_or_(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.or_(a, b)
+
+
+def operator_and_(size):
+    a = Array(size, 'int32')
+    b = Array(size, 'int32')
+    for i in range(size):
+        a[i] = nb_types.int32(i)
+        b[i] = nb_types.int32(size-i-1)
+    return operator.and_(a, b)
 
 
 def operator_eq(size, v):

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -1135,6 +1135,9 @@ if nb is not None:
     boolean1 = Boolean1('boolean1')
     boolean8 = Boolean8('boolean8')
 
+    _numba_imap[boolean1] = 'bool'
+    _numba_imap[boolean8] = 'int8'
+
     @lower_cast(Boolean1, nb.types.Boolean)
     @lower_cast(Boolean8, nb.types.Boolean)
     def literal_booleanN_to_boolean(context, builder, fromty, toty, val):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def setup_package():
         setup_requires = []
         tests_require = []
     else:
-        install_requires = ["numba", "llvmlite>=0.29", "tblib", "thriftpy2",
+        install_requires = ["numba", "llvmlite>=0.33.0", "tblib", "thriftpy2",
                             "six", "netifaces"]
         setup_requires = ['pytest-runner']
         tests_require = ['pytest']


### PR DESCRIPTION
This PR implements the following operators for Omnisci arrays:

- operator.add
- operator.iadd
- operator.and_
- operator.iand_
- operator.eq
- operator.ge
- operator.floordiv
- operator.ifloordiv
- operator.gt
- operator.in
- operator.is
- operator.is_not
- operator.le
- operator.lshift
- operator.ilshift
- operator.lt
- operator.mul
- operator.imul
- operator.ne
- operator.not_in
- operator.or_
- operator.ior
- operator.pow
- operator.ipow
- operator.rshift
- operator.irshift
- operator.sub
- operator.isub
- operator.truediv
- operator.itruediv
- operator.xor
- operator.ixor
- operator.abs
- operator.net
- operator.pos

And the numpy function `invert`

Edit: A complete list of Python operators can be found in the link below:
https://github.com/xnd-project/rbc/issues/90
