### PR TITLE
Skip test_array_constructor_return when using omniscidb 5.3.1.

### DIFF
--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -482,10 +482,10 @@ class RemoteJIT(object):
         """
         thrift_file = os.path.join(os.path.dirname(__file__),
                                    'remotejit.thrift')
-        print('staring rpc.thrift server: %s' % (thrift_file), end='')
+        print('staring rpc.thrift server: %s' % (thrift_file), end='', flush=True)
 
         if self.debug:
-            print()
+            print(flush=True)
             dispatcher = DebugDispatcherRJIT
         else:
             dispatcher = DispatcherRJIT
@@ -496,7 +496,7 @@ class RemoteJIT(object):
         else:
             Server.run(dispatcher, thrift_file,
                        dict(host=self.host, port=self.port))
-            print('... rpc.thrift server stopped')
+            print('... rpc.thrift server stopped', flush=True)
 
     def stop_server(self):
         """Stop remotejit server from client.

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -482,7 +482,8 @@ class RemoteJIT(object):
         """
         thrift_file = os.path.join(os.path.dirname(__file__),
                                    'remotejit.thrift')
-        print('staring rpc.thrift server: %s' % (thrift_file), end='', flush=True)
+        print('staring rpc.thrift server: %s' % (thrift_file), end='',
+              flush=True)
 
         if self.debug:
             print(flush=True)

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -319,9 +319,9 @@ def test_array_constructor_noreturn(omnisci):
 
 
 def test_array_constructor_return(omnisci):
-    if available_version[:2] >= (5, 4):
+    if available_version[:3] >= (5, 3, 1):
         pytest.skip(
-            'crashes CPU-only omniscidb server v 5.4 [issue 112]')
+            'crashes CPU-only omniscidb server v 5.3.1+ [issue 112]')
 
     omnisci.reset()
 

--- a/rbc/tests/test_omnisci_array_functions.py
+++ b/rbc/tests/test_omnisci_array_functions.py
@@ -131,7 +131,7 @@ array_methods = [
 @pytest.mark.parametrize("method, signature, args, expected", array_methods,
                          ids=[item[0] for item in array_methods])
 def test_array_methods(omnisci, method, signature, args, expected):
-    if (available_version[:2] == (5, 4)
+    if (available_version[:3] >= (5, 3, 1)
         and method in ['full', 'full_dtype', 'ones', 'ones_dtype', 'zeros',
                        'zeros_dtype', 'cumsum']):
         pytest.skip(

--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -122,11 +122,11 @@ def test_ndarray_methods(omnisci, method, signature, args, expected):
         pytest.skip(
             f'{method}: crashes CUDA enabled omniscidb server [issue 93]')
 
-    if available_version[:2] == (5, 4) and method in ['fill']:
+    if available_version[:3] >= (5, 3, 1) and method in ['fill']:
         pytest.skip(
             f'{method}: crashes CPU-only omniscidb server v 5.4 [issue 113]')
 
-    if available_version[:2] == (5, 4) and method in ['max_empty']:
+    if available_version[:3] >= (5, 3, 1) and method in ['max_empty']:
         pytest.skip(
             f'{method}: fails on CPU-only omniscidb server v 5.4 [issue 114]')
 

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -492,7 +492,7 @@ def test_array_operators(omnisci, suffix, signature, args, expected):
         pytest.skip(f'operator_{suffix}: crashes CUDA enabled omniscidb server'
                     ' [rbc issue 107]')
 
-    if (available_version[:2] == (5, 4)
+    if (available_version[:3] >= (5, 3, 1)
         and suffix in ['abs', 'add', 'and_bw', 'eq', 'floordiv', 'floordiv2',
                        'ge', 'gt', 'iadd', 'iand', 'ifloordiv', 'ifloordiv2',
                        'ilshift', 'imul', 'ior', 'isub', 'ipow', 'irshift',

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -13,7 +13,7 @@ def Type_fromstring(s):
 
 @pytest.fixture(scope="module")
 def rjit(request):
-    rjit = RemoteJIT()
+    rjit = RemoteJIT(debug=True)
     rjit.start_server(background=True)
     request.addfinalizer(rjit.stop_server)
     atexit.register(rjit.stop_server)


### PR DESCRIPTION
Resolves issue #132 .