### PR TITLE
Backport to numba 0.48

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -241,7 +241,8 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo,
     flags = compiler.Flags()
     flags.set('no_compile')
     flags.set('no_cpython_wrapper')
-    flags.set('no_cfunc_wrapper')
+    if get_version('numba') >= (0, 49):
+        flags.set('no_cfunc_wrapper')
 
     function_names = []
     for func, signatures in functions_and_signatures:


### PR DESCRIPTION
no_cfunc_wrapper flag was introduced in numba 0.49.
Fixes #138 .