### PR TITLE
enable boolean8 tests and call functions from the "omni" pkg

### DIFF
--- a/rbc/omnisci_backend/numpy_ufuncs.py
+++ b/rbc/omnisci_backend/numpy_ufuncs.py
@@ -16,10 +16,13 @@ def determine_dtype(a, dtype):
 
 
 def determine_input_type(argty):
+    if isinstance(argty, ArrayPointer):
+        return determine_input_type(argty.eltype)
+
     if argty == typesystem.boolean8:
         return bool
     else:
-        return argty.eltype if isinstance(argty, ArrayPointer) else argty
+        return argty
 
 
 def overload_elementwise_binary_ufunc(ufunc, name=None, dtype=None):
@@ -226,7 +229,7 @@ def overload_elementwise_unary_ufunc(ufunc, name=None, dtype=None):
 # not supported?
 # @overload_elementwise_unary_ufunc(np.isnat, dtype=types.int8)
 # @overload_elementwise_unary_ufunc(np.signbit, dtype=types.int8)
-@overload_elementwise_unary_ufunc(np.copysign, dtype=types.int8)
+@overload_elementwise_unary_ufunc(np.copysign)
 # @overload_elementwise_unary_ufunc(np.spacing, dtype=types.double)
 def dummy_unary_ufunc(a):
     pass

--- a/rbc/tests/test_omnisci_array_math.py
+++ b/rbc/tests/test_omnisci_array_math.py
@@ -235,14 +235,14 @@ unary_fns = [
     ('deg2rad', 'double[](double[])', 'f8'),
     ('rad2deg', 'double[](double[])', 'f8'),
     # comparison functions
-    ('logical_not', 'int8[](int64[])', 'i8'),
+    ('logical_not', 'bool[](int64[])', 'i8'),
     # floating functions
-    ('isfinite', 'int8[](int64[])', 'i8'),
-    ('isinf', 'int8[](int64[])', 'i8'),
-    ('isnan', 'int8[](int64[])', 'i8'),
-    # ('isnat', 'int8[](int64[])', 'i8'), # doesn't work
+    ('isfinite', 'bool[](int64[])', 'i8'),
+    ('isinf', 'bool[](int64[])', 'i8'),
+    ('isnan', 'bool[](int64[])', 'i8'),
+    # ('isnat', 'bool[](int64[])', 'i8'), # doesn't work
     ('fabs', 'double[](double[])', 'f8'),
-    # ('signbit', 'int8[](int64[])', 'i8'), # not supported
+    # ('signbit', 'bool[](int64[])', 'i8'), # not supported
     # ('spacing', 'double[](double[])', 'f8'), # not supported
     ('floor', 'double[](double[])', 'f8'),
     ('ceil', 'double[](double[])', 'f8'),

--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -192,8 +192,8 @@ def test_numpy_function(omnisci, fn_name, signature, np_func):
         # Invalid use of Function(<ufunc 'logical_or'>) with
         # argument(s) of type(s): (boolean8, boolean8)
         pytest.skip(
-            f'using boolean8 as {fn_name} argument not implemented for'
-            ' omniscidb server < v 5.4')
+            f"using boolean arguments requires omniscidb v 5.4 or newer"
+            " (got {available_version})"
 
     if fn_name in ['positive', 'divmod0', 'frexp0']:
         try:

--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -123,7 +123,6 @@ numpy_functions = [
     ('left_shift', 'int64(int64, int64)', np.left_shift),
     # Misc functions
     ('heaviside', 'double(double, double)', np.heaviside),
-    ('heaviside', 'double(bool, bool)', np.heaviside),
     ('copysign', 'double(double, double)', np.copysign),
     # Bit functions:
     ('invert', 'int(int)', np.invert),

--- a/rbc/tests/test_omnisci_math.py
+++ b/rbc/tests/test_omnisci_math.py
@@ -193,7 +193,7 @@ def test_numpy_function(omnisci, fn_name, signature, np_func):
         # argument(s) of type(s): (boolean8, boolean8)
         pytest.skip(
             f"using boolean arguments requires omniscidb v 5.4 or newer"
-            " (got {available_version})"
+            f" (got {available_version})")
 
     if fn_name in ['positive', 'divmod0', 'frexp0']:
         try:


### PR DESCRIPTION
- explicit cast of boolean8 to bool
- call functions from omni. pkg rather than np.
- replace int8[] by bool[] in some tests

This PR requires a small change in omniscidb to handle boolean values: https://github.com/omnisci/omniscidb-internal/pull/4689