### PR TITLE
Eliminate bool_is_int8 from mangling algorithm

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -247,7 +247,7 @@ def compile_to_LLVM(functions_and_signatures, target: TargetInfo,
     function_names = []
     for func, signatures in functions_and_signatures:
         for sig in signatures:
-            fname = func.__name__ + sig.mangling(bool_is_int8=True)
+            fname = func.__name__ + sig.mangling()
             function_names.append(fname)
             args, return_type = sigutils.normalize_signature(
                 sig.tonumba(bool_is_int8=True))

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -458,7 +458,7 @@ class RemoteOmnisci(RemoteJIT):
                         sizer_type = getattr(
                             thrift.TOutputBufferSizeType, sizer)
                         udtfs.append(thrift.TUserDefinedTableFunction(
-                            name + sig.mangling(bool_is_int8=True),
+                            name + sig.mangling(),
                             sizer_type, sizer_index,
                             inputArgTypes, outputArgTypes, sqlArgTypes))
                     else:
@@ -467,7 +467,7 @@ class RemoteOmnisci(RemoteJIT):
                         atypes = [ext_arguments_map[a.tostring(
                             use_annotation=False)] for a in sig[1]]
                         udfs.append(thrift.TUserDefinedFunction(
-                            name + sig.mangling(bool_is_int8=True),
+                            name + sig.mangling(),
                             atypes, rtype))
                     signatures.append(sig)
                 functions_and_signatures.append((caller.func, signatures))

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -319,9 +319,9 @@ def test_array_constructor_noreturn(omnisci):
 
 
 def test_array_constructor_return(omnisci):
-    if available_version[:3] >= (5, 3, 1):
+    if available_version[:3] == (5, 3, 1):
         pytest.skip(
-            'crashes CPU-only omniscidb server v 5.3.1+ [issue 112]')
+            'crashes CPU-only omniscidb server v 5.3.1 [issue 112]')
 
     omnisci.reset()
 

--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -127,11 +127,12 @@ def test_ndarray_methods(omnisci, method, signature, args, expected):
 
     if available_version[:3] == (5, 3, 1) and method in ['fill']:
         pytest.skip(
-            f'{method}: crashes CPU-only omniscidb server v 5.3 [issue 113]')
+            f'{method}: crashes CPU-only omniscidb server v 5.3.1 [issue 113]')
 
     if available_version[:3] >= (5, 3, 1) and method in ['max_empty']:
         pytest.skip(
-            f'{method}: fails on CPU-only omniscidb server v 5.4 [issue 114]')
+            f'{method}: fails on CPU-only omniscidb server'
+            ' v 5.3.1+ [issue 114]')
 
     omnisci(signature)(eval('ndarray_{}'.format(method)))
 

--- a/rbc/tests/test_omnisci_array_operators.py
+++ b/rbc/tests/test_omnisci_array_operators.py
@@ -503,7 +503,7 @@ def test_array_operators(omnisci, suffix, signature, args, expected):
                        'lt', 'mul', 'mod', 'ne', 'neg', 'or_bw', 'pos', 'pow',
                        'rshift', 'sub', 'truediv', 'truediv2', 'xor']):
         pytest.skip(
-            f'operator_{suffix}: crashes CPU-only omniscidb server v 5.3'
+            f'operator_{suffix}: crashes CPU-only omniscidb server v 5.3.1'
             ' [issue 115]')
 
     omnisci.reset()

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -377,9 +377,9 @@ class Type(tuple):
         """
         self._mangling = mangling
 
-    def mangling(self, bool_is_int8=None):
+    def mangling(self):
         if self._mangling is None:
-            self._mangling = self.mangle(bool_is_int8=bool_is_int8)
+            self._mangling = self.mangle()
         return self._mangling
 
     @property
@@ -570,7 +570,7 @@ class Type(tuple):
         if self.is_struct:
             struct_name = self._params.get('name')
             if struct_name is None:
-                struct_name = 'STRUCT'+self.mangling(bool_is_int8=bool_is_int8)
+                struct_name = 'STRUCT'+self.mangling()
             members = []
             for i, member in enumerate(self):
                 name = member._params.get('name', '_%s' % (i+1))
@@ -917,7 +917,7 @@ class Type(tuple):
                 **params)
         raise NotImplementedError(repr(self))
 
-    def mangle(self, bool_is_int8=None):
+    def mangle(self):
         """Return mangled type string.
 
         Mangled type string is a string representation of the type
@@ -927,13 +927,13 @@ class Type(tuple):
         if self.is_void:
             return 'v'
         if self.is_pointer:
-            return '_' + self[0].mangle(bool_is_int8=bool_is_int8) + 'P'
+            return '_' + self[0].mangle() + 'P'
         if self.is_struct:
-            return '_' + ''.join(m.mangle(bool_is_int8=bool_is_int8)
+            return '_' + ''.join(m.mangle()
                                  for m in self) + 'K'
         if self.is_function:
-            r = self[0].mangle(bool_is_int8=bool_is_int8)
-            a = ''.join([a.mangle(bool_is_int8=bool_is_int8) for a in self[1]])
+            r = self[0].mangle()
+            a = ''.join([a.mangle() for a in self[1]])
             return '_' + r + 'a' + a + 'A'
         if self.is_atomic:
             n = _mangling_map.get(self[0])


### PR DESCRIPTION
`bool_is_int8` ought to be used only when converting typesystem types to numba types.