### PR TITLE
Ensure that sizer is specified to have type int32.

### DIFF
--- a/rbc/omnisci_backend/omnisci_column.py
+++ b/rbc/omnisci_backend/omnisci_column.py
@@ -6,8 +6,10 @@ UDTFs.
 
 __all__ = ['ColumnPointer', 'OutputColumn', 'Column',
            'OmnisciOutputColumnType', 'OmnisciColumnType',
-           'output_column_type_converter', 'column_type_converter']
+           'output_column_type_converter', 'column_type_converter',
+           'table_function_sizer_type_converter']
 
+from rbc import typesystem
 from rbc.utils import get_version
 from .omnisci_buffer import (
     BufferPointer, Buffer, BufferPointerModel,
@@ -76,3 +78,17 @@ def output_column_type_converter(target_info, obj):
     return buffer_type_converter(
         target_info, obj, OmnisciOutputColumnType, 'OutputColumn',
         ColumnPointer, extra_members=[])
+
+
+def table_function_sizer_type_converter(target_info, obj):
+    """Return Type instance corresponding to sizer argument of a
+    user-defined table function.
+    """
+    if not isinstance(obj, typesystem.Type):
+        raise NotImplementedError(type(obj))
+    if obj.is_atomic:
+        sizer_name = obj[0]
+        sizer_types = ['RowMultiplier', 'ConstantParameter', 'Constant']
+        if sizer_name in sizer_types:
+            return typesystem.Type.fromstring(f'int32|sizer={sizer_name}',
+                                              target_info=target_info)

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -623,8 +623,9 @@ class RemoteOmnisci(RemoteJIT):
                             annot = a.annotation()
                             _sizer = annot.get('sizer', unspecified)
                             if _sizer is not unspecified:
-                                # sizer must have type int32
-                                assert a.is_int and a.bits == 32, a
+                                if not (a.is_int and a.bits == 32):
+                                    raise ValueError(
+                                        'sizer argument must have type int32')
                                 if _sizer is None:
                                     _sizer = 'RowMultiplier'
                                 _sizer = sizer_map[_sizer]

--- a/rbc/tests/test_omnisci_black_scholes.py
+++ b/rbc/tests/test_omnisci_black_scholes.py
@@ -80,7 +80,7 @@ def cnd_numba(d):
 def test_black_scholes_udf(omnisci):
     if omnisci.has_cuda:
         pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [issue 147]')
+                    ' [issue 60]')
 
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
@@ -116,7 +116,7 @@ def test_black_scholes_udf(omnisci):
 def test_black_scholes_udtf(omnisci):
     if omnisci.has_cuda:
         pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [issue 147]')
+                    ' [issue 169]')
 
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
@@ -125,7 +125,7 @@ def test_black_scholes_udtf(omnisci):
     omnisci.register()
 
     @omnisci('int32(Column<double>, Column<double>, Column<double>, Column<double>, Column<double>,'  # noqa: E501
-             ' int64|sizer=RowMultiplier, OutputColumn<double>)')
+             ' RowMultiplier, OutputColumn<double>)')
     def black_scholes_udtf(S, X, T, r, sigma, m, out):
         input_row_count = len(X)
 

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -47,17 +47,13 @@ def omnisci():
 
 
 def test_sizer_row_multiplier_orig(omnisci):
-    if omnisci.has_cuda:
-        pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [rbc issue 147]')
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL
     # queries:
     omnisci.register()
 
-    @omnisci('int32(Column<double>, int64|sizer=RowMultiplier,'
-             ' OutputColumn<double>)')
+    @omnisci('int32(Column<double>, RowMultiplier, OutputColumn<double>)')
     def my_row_copier_mul(x, m, y):
         input_row_count = len(x)
         for i in range(input_row_count):
@@ -76,17 +72,13 @@ def test_sizer_row_multiplier_orig(omnisci):
 
 
 def test_sizer_row_multiplier_param1(omnisci):
-    if omnisci.has_cuda:
-        pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [rbc issue 147]')
-
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL
     # queries:
     omnisci.register()
 
-    @omnisci('int32(Column<double>, double, int32, int64|sizer=RowMultiplier,'
+    @omnisci('int32(Column<double>, double, int32, RowMultiplier,'
              'OutputColumn<double>)')
     def my_row_copier_mul_param1(x, alpha, beta, m, y):
         input_row_count = len(x)
@@ -110,17 +102,13 @@ def test_sizer_row_multiplier_param1(omnisci):
 
 
 def test_sizer_row_multiplier_param2(omnisci):
-    if omnisci.has_cuda:
-        pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [rbc issue 147]')
-
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL
     # queries:
     omnisci.register()
 
-    @omnisci('int32(double, Column<double>, int32, int64|sizer=RowMultiplier,'
+    @omnisci('int32(double, Column<double>, int32, RowMultiplier,'
              'OutputColumn<double>)')
     def my_row_copier_mul_param2(alpha, x, beta, m, y):
         input_row_count = len(x)
@@ -156,8 +144,7 @@ def test_sizer_constant_parameter(omnisci):
     # queries:
     omnisci.register()
 
-    @omnisci('int32(Column<double>, int64|sizer=ConstantParameter,'
-             ' Column<double>)')
+    @omnisci('int32(Column<double>, ConstantParameter, Column<double>)')
     def my_row_copier_cp(x, m, y):
         input_row_count = len(x)
         for i in range(input_row_count):
@@ -181,10 +168,6 @@ def test_sizer_constant_parameter(omnisci):
         "test requires omniscidb v 5.4 or newer (got %s) [issue 148]" % (
             available_version,)))
 def test_rowmul_add_columns(omnisci):
-    if omnisci.has_cuda:
-        pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [issue 147]')
-
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL
@@ -192,7 +175,7 @@ def test_rowmul_add_columns(omnisci):
     omnisci.register()
 
     @omnisci('int32(Column<double>, Column<double>, double,'
-             ' int64|sizer=RowMultiplier, OutputColumn<double>)')
+             ' RowMultiplier, OutputColumn<double>)')
     def add_columns(x, y, alpha, m, r):
         input_row_count = len(x)
         for i in range(input_row_count):
@@ -230,7 +213,7 @@ def test_rowmul_return_two_columns(omnisci):
     # queries:
     omnisci.register()
 
-    @omnisci('int32(Column<double>, int64|sizer=RowMultiplier,'
+    @omnisci('int32(Column<double>, RowMultiplier,'
              ' OutputColumn<double>, OutputColumn<double>)')
     def ret_columns(x, m, y, z):
         input_row_count = len(x)

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -206,7 +206,7 @@ def test_rowmul_add_columns(omnisci):
 def test_rowmul_return_two_columns(omnisci):
     if omnisci.has_cuda:
         pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [rbc issue 147]')
+                    ' [rbc issue 171]')
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -204,10 +204,6 @@ def test_rowmul_add_columns(omnisci):
         " columns support (got %s) [issue 150]" % (
             available_version,)))
 def test_rowmul_return_mixed_columns(omnisci):
-    if omnisci.has_cuda:
-        # requires omniscidb-internal PR 4785
-        pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [rbc issue 171]')
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL
@@ -260,10 +256,6 @@ def test_rowmul_return_mixed_columns(omnisci):
 @pytest.mark.parametrize("sizer", [1, 2])
 @pytest.mark.parametrize("num_columns", [1, 2, 3, 4])
 def test_rowmul_return_multi_columns(omnisci, num_columns, sizer, max_n):
-    if omnisci.has_cuda:
-        # requires omniscidb-internal PR 4785
-        pytest.skip('crashes CUDA enabled omniscidb server'
-                    ' [rbc issue 171]')
     omnisci.reset()
     # register an empty set of UDFs in order to avoid unregistering
     # UDFs created directly from LLVM IR strings when executing SQL
@@ -335,6 +327,7 @@ def test_rowmul_return_multi_columns(omnisci, num_columns, sizer, max_n):
         f'cursor(select f8 from {omnisci.table_name}), {sizer}));')
 
     result = list(result)
+
     if max_n == -1:
         assert len(result) == sizer * 5
     else:


### PR DESCRIPTION
Fixes #147.

This PR introduces a new type specifications `RowMultiplier` that is an alias to `int32|sizer=RowMultiplier`.