### PR TITLE
Expose RemoteOmnisci

### DIFF
--- a/rbc/__init__.py
+++ b/rbc/__init__.py
@@ -1,6 +1,7 @@
 # Expose a temporary prototype. It will be replaced by proper
 # implementation soon.
 from .remotejit import RemoteJIT  # noqa: F401
+from .omniscidb import RemoteOmnisci  # noqa: F401
 
 from ._version import get_versions
 __version__ = get_versions()['version']


### PR DESCRIPTION
As title.

Without this changes:
```python
~ (rbc) guilhermel@qgpu2 $ python
Python 3.8.3 | packaged by conda-forge | (default, Jun  1 2020, 17:43:00)
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rbc
>>> rbc.omniscidb
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'rbc' has no attribute 'omniscidb'
>>> dir(rbc)
['RemoteJIT', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_version', 'irtools', 'npy_mathimpl', 'remotejit', 'targetinfo', 'thrift', 'typesystem', 'utils']
```

With this changes
```python
~ (rbc) guilhermel@qgpu2 $ python
Python 3.8.3 | packaged by conda-forge | (default, Jun  1 2020, 17:43:00)
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rbc
dir(rbc)
>>> dir(rbc)
['RemoteJIT', 'RemoteOmnisci', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_version', 'errors', 'irtools', 'npy_mathimpl', 'omnisci_backend', 'omniscidb', 'remotejit', 'targetinfo', 'thrift', 'typesystem', 'utils']
>>> rbc.omniscidb
<module 'rbc.omniscidb' from '/work/guilhermel/git/rbc/rbc/omniscidb.py'>
>>>
```
I might need to do another release of RBC after this.