### PR TITLE
Support multiple columns in a single cursor argument of a UDTF.

### DIFF
--- a/rbc/omnisci_backend/omnisci_column.py
+++ b/rbc/omnisci_backend/omnisci_column.py
@@ -110,7 +110,17 @@ def cursor_type_converter(target_info, obj):
         raise NotImplementedError(type(obj))
     name, params = obj.get_name_and_parameters()
     if name == 'Cursor':
-        cursor_type = OmnisciCursorType(*tuple(typesystem.Type.fromstring(
-            p, target_info=target_info) for p in params))
+        new_params = []
+        for p in params:
+            p = typesystem.Type.fromstring(p, target_info=target_info)
+            if p.is_float or p.is_int or p.is_bool:
+                p = typesystem.Type.fromstring(
+                    f'Column<{p}>', target_info=target_info)
+            if not isinstance(p, OmnisciColumnType):
+                raise TypeError(
+                    f'expected OmnisciColumnType|float|int|bool as'
+                    f' OmnisciCursorType argument but got `{p}`')
+            new_params.append(p)
+        cursor_type = OmnisciCursorType(*new_params)
         cursor_type._params['clsname'] = name
         return cursor_type

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -174,7 +174,7 @@ class Signature(object):
                 raise ValueError(
                     'expected signature representing function type,'
                     f' got `{sig}`')
-            if len(sig[1]) != nargs:
+            if sig.arity != nargs:
                 raise ValueError(f'signature `{sig}` must have arity {nargs}'
                                  f' but got {len(sig[1])}')
             if fsig is not None:

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -335,3 +335,54 @@ def test_rowmul_return_multi_columns(omnisci, num_columns, sizer, max_n):
     for i, r in enumerate(result):
         for j, v in enumerate(r):
             assert v == float((i+1) * (j+1))
+
+
+@pytest.mark.skipif(
+    available_version < (5, 5),
+    reason=(
+        "test requires omniscidb with single cursor"
+        " support (got %s) [issue 173]" % (
+            available_version,)))
+def test_issue173(omnisci):
+
+    @omnisci('int32(Column<double>, Column<bool>, RowMultiplier,'
+             ' OutputColumn<double>)')
+    def mask_zero(x, b, m, y):
+        for i in range(len(x)):
+            if b[i]:
+                y[i] = 0.0
+            else:
+                y[i] = x[i]
+        return len(x)
+
+    descr, result = omnisci.sql_execute(
+        f'select f8, b from {omnisci.table_name}')
+    f8, b = zip(*list(result))
+
+    descr, result = omnisci.sql_execute(
+        f'select * from table(mask_zero('
+        f'cursor(select f8 from {omnisci.table_name}),'
+        f'cursor(select b from {omnisci.table_name}), 1))')
+
+    result = list(result)
+
+    for i in range(len(result)):
+        assert result[i][0] == (0.0 if b[i] else f8[i])
+
+    @omnisci('int32(Cursor<Column<double>, Column<bool>>, RowMultiplier,'
+             ' OutputColumn<double>)')
+    def mask_zero2(x, b, m, y):
+        for i in range(len(x)):
+            if b[i]:
+                y[i] = 0.0
+            else:
+                y[i] = x[i]
+        return len(x)
+
+    descr, result = omnisci.sql_execute(
+        f'select * from table(mask_zero2('
+        f'cursor(select f8, b from {omnisci.table_name}), 1))')
+
+    result = list(result)
+    for i in range(len(result)):
+        assert result[i][0] == (0.0 if b[i] else f8[i])


### PR DESCRIPTION
Fixes #173 .
Requires omniscidb 5.5 and https://github.com/omnisci/omniscidb-internal/pull/4856 .

Example:
```
@omnisci('int32(Cursor<double, bool>, RowMultiplier, OutputColumn<double>)')
    def mask_zero(x, b, m, y):
        for i in range(len(x)):
            y[i] = x[i] if b[i] else 0.0
        return len(x)

omnisci.sql_execute('select * from table(mask_zero(cursor(select x, b from mytable), 1)')
```

