### PR TITLE
Support TEXT ENCODING NONE as Bytes

### DIFF
--- a/rbc/omnisci_backend/__init__.py
+++ b/rbc/omnisci_backend/__init__.py
@@ -2,6 +2,7 @@ from .numpy_funcs import *  # noqa: F401, F403
 from .npy_mathimpl import *  # noqa: F401, F403
 from .omnisci_array import *  # noqa: F401, F403
 from .omnisci_column import *  # noqa: F401, F403
+from .omnisci_bytes import *  # noqa: F401, F403
 from .numpy_ufuncs import *  # noqa: F401, F403
 from .omnisci_pipeline import *  # noqa: F401, F403
 from .python_operators import *  # noqa: F401, F403

--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -123,7 +123,7 @@ def omnisci_buffer_constructor(context, builder, sig, args):
 
       extending.lower_builtin(MyBuffer, numba.types.Integer, ...)(omnisci_buffer_constructor)
 
-    will enable creating MyBuffer intance from a Omnisci UDF/UDTF definition:
+    will enable creating MyBuffer instance from a Omnisci UDF/UDTF definition:
 
       b = MyBuffer(<size>, ...)
 

--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -24,9 +24,11 @@ Omnisci buffer objects from UDF/UDTFs.
 
 
 import operator
+from collections import defaultdict
 from llvmlite import ir
 from rbc import typesystem
 from rbc.utils import get_version
+from llvmlite import ir as llvm_ir
 if get_version('numba') >= (0, 49):
     from numba.core import datamodel, cgutils, extending, types
 else:
@@ -73,6 +75,7 @@ class BufferPointer(types.Type):
     used to access the data stored in Buffer ptr member.
     """
     mutable = True
+    return_as_first_argument = True
 
     def __init__(self, dtype, eltype):
         self.dtype = dtype    # struct dtype
@@ -85,7 +88,15 @@ class BufferPointer(types.Type):
         return self.dtype
 
 
-class Buffer(object):
+class BufferMeta(type):
+
+    class_names = set()
+
+    def __init__(cls, name, bases, dct):
+        type(cls).class_names.add(name)
+
+
+class Buffer(object, metaclass=BufferMeta):
     """Represents Omnisci Buffer that can be constructed within UDF/UDTFs.
     """
 
@@ -100,6 +111,81 @@ class BufferPointerModel(datamodel.models.PointerModel):
       class ArrayPointerModel(BufferPointerModel):
           pass
     """
+
+
+builder_buffers = defaultdict(list)
+
+
+def omnisci_buffer_constructor(context, builder, sig, args):
+    """
+
+    Usage:
+
+      extending.lower_builtin(MyBuffer, numba.types.Integer, ...)(omnisci_buffer_constructor)
+
+    will enable creating MyBuffer intance from a Omnisci UDF/UDTF definition:
+
+      b = MyBuffer(<size>, ...)
+
+    """
+    ptr_type, sz_type = sig.return_type.dtype.members[:2]
+    if len(sig.return_type.dtype.members) > 2:
+        assert len(sig.return_type.dtype.members) == 3
+        null_type = sig.return_type.dtype.members[2]
+    else:
+        null_type = None
+    assert isinstance(args[0].type, ir.IntType), (args[0].type)
+    element_count = builder.zext(args[0], int64_t)
+    element_size = int64_t(ptr_type.dtype.bitwidth // 8)
+
+    alloc_fnty = ir.FunctionType(int8_t.as_pointer(), [int64_t, int64_t])
+
+    # TODO: use omnisci alloc function instead of calloc, see rbc issue 87
+    alloc_fn = builder.module.get_or_insert_function(
+        alloc_fnty, name="calloc")
+    ptr8 = builder.call(alloc_fn, [element_count, element_size])
+    # remember possible temporary allocations so that when leaving a
+    # UDF/UDTF, these will be deallocated, see omnisci_pipeline.py.
+    builder_buffers[builder].append(ptr8)
+    ptr = builder.bitcast(ptr8, context.get_value_type(ptr_type))
+
+    fa = cgutils.create_struct_proxy(sig.return_type.dtype)(context, builder)
+    fa.ptr = ptr                  # T*
+    fa.sz = element_count         # size_t
+    if null_type is not None:
+        is_null = context.get_value_type(null_type)(0)
+        fa.is_null = is_null      # int8_t
+    return fa._getpointer()
+
+
+@extending.intrinsic
+def free_omnisci_buffer(typingctx, ret):
+    sig = types.void(ret)
+
+    def codegen(context, builder, signature, args):
+        buffers = builder_buffers[builder]
+
+        # TODO: using stdlib `free` that works only for CPU. For CUDA
+        # devices, we need to use omniscidb provided deallocator.
+        free_fnty = llvm_ir.FunctionType(void_t, [int8_t.as_pointer()])
+        free_fn = builder.module.get_or_insert_function(free_fnty, name="free")
+
+        # We skip the ret pointer iff we're returning a Buffer
+        # otherwise, we free everything
+        if isinstance(ret, BufferPointer):
+            [arg] = args
+            ptr = builder.load(builder.gep(arg, [int32_t(0), int32_t(0)]))
+            ptr = builder.bitcast(ptr, int8_t.as_pointer())
+            for ptr8 in buffers:
+                with builder.if_then(builder.icmp_signed('!=', ptr, ptr8)):
+                    builder.call(free_fn, [ptr8])
+        else:
+            for ptr8 in buffers:
+                builder.call(free_fn, [ptr8])
+
+        del builder_buffers[builder]
+
+    return sig, codegen
 
 
 @extending.intrinsic
@@ -260,6 +346,28 @@ def omnisci_buffer_setitem(a, i, v):
         return lambda a, i, v: omnisci_buffer_setitem_(a, i, v)
 
 
+@extending.intrinsic
+def omnisci_buffer_is_null_(typingctx, data):
+    sig = types.int8(data)
+
+    def codegen(context, builder, signature, args):
+
+        rawptr = cgutils.alloca_once_value(builder, value=args[0])
+        ptr = builder.load(rawptr)
+
+        return builder.load(builder.gep(ptr, [int32_t(0), int32_t(2)]))
+
+    return sig, codegen
+
+
+@extending.overload_method(BufferPointer, 'is_null')
+def omnisci_buffer_is_null(x):
+    if isinstance(x, BufferPointer):
+        def impl(x):
+            return omnisci_buffer_is_null_(x)
+        return impl
+
+
 def make_buffer_ptr_type(buffer_type, buffer_ptr_cls):
     ptr_type = buffer_type.pointer()
 
@@ -274,7 +382,7 @@ def make_buffer_ptr_type(buffer_type, buffer_ptr_cls):
 
 def buffer_type_converter(obj, typesystem_buffer_type,
                           buffer_typename, buffer_ptr_cls,
-                          extra_members=[]):
+                          extra_members=[], element_type=None):
     """Template function for converting typesystem Type instances to
     Omnisci Buffer Type instance.
 
@@ -288,7 +396,8 @@ def buffer_type_converter(obj, typesystem_buffer_type,
     buffer_ptr_cls : {BufferPointer subclass}
     extra_members : {list of typesystem Type instances}
       Additional members of the buffer structure.
-
+    element_type : {None, typesystem Type instance}
+      Specify element type. Otherwise deduce it from `obj` parameters.
     """
     if isinstance(obj, str):
         obj = typesystem.Type(obj,)
@@ -300,19 +409,24 @@ def buffer_type_converter(obj, typesystem_buffer_type,
     #   typesystem.Type('BufferTypeName<ElementType>', )
     # In all other cases refuse by returning None.
 
-    name, params = obj.get_name_and_parameters()
-    if name is None or name != buffer_typename:
-        return
-    assert len(params) == 1, params
-    t = typesystem.Type.fromstring(params[0])
-    if not t.is_concrete:
-        return
+    if element_type is None:
+        name, params = obj.get_name_and_parameters()
+        if name is None or name != buffer_typename:
+            return
+        assert len(params) == 1, params
+        element_type = typesystem.Type.fromstring(params[0])
+        if not element_type.is_concrete:
+            return
+        typename = '%s<%s>' % (buffer_typename, element_type.toprototype())
+    else:
+        element_type = typesystem.Type.fromobject(element_type)
+        typename = buffer_typename
 
     assert issubclass(buffer_ptr_cls, BufferPointer)
     assert issubclass(typesystem_buffer_type, OmnisciBufferType)
 
     # Construct buffer type as a struct with ptr and sz as members.
-    ptr_t = typesystem.Type(t, '*', name='ptr')
+    ptr_t = typesystem.Type(element_type, '*', name='ptr')
     size_t = typesystem.Type.fromstring('size_t sz')
     buffer_type = typesystem_buffer_type(
         ptr_t,
@@ -326,7 +440,6 @@ def buffer_type_converter(obj, typesystem_buffer_type,
     buffer_type._params['numba.Type'] = BufferType
 
     # Create alias to buffer type
-    typename = '%s<%s>' % (buffer_typename, t.toprototype())
     buffer_type._params['typename'] = typename
 
     # In omniscidb, boolean values are stored as int8 because

--- a/rbc/omnisci_backend/omnisci_bytes.py
+++ b/rbc/omnisci_backend/omnisci_bytes.py
@@ -1,0 +1,74 @@
+'''Omnisci Bytes type that corresponds to Omnisci type TEXT ENCODED NONE.
+
+Omnisci Bytes represents the following structure:
+
+  struct Bytes {
+    char* ptr;
+    size_t sz;  // when non-negative, Bytes has fixed width.
+  }
+'''
+
+__all__ = ['BytesPointer', 'Bytes', 'bytes_type_converter', 'OmnisciBytesType']
+
+from rbc import typesystem
+from rbc.utils import get_version
+from .omnisci_buffer import (
+    BufferPointer, Buffer, BufferPointerModel,
+    buffer_type_converter, OmnisciBufferType,
+    omnisci_buffer_constructor
+)
+
+if get_version('numba') >= (0, 49):
+    from numba.core import datamodel, types, extending
+else:
+    from numba import datamodel, types, extending
+
+
+class OmnisciBytesType(OmnisciBufferType):
+    """Omnisci Bytes type for RBC typesystem.
+    """
+
+
+class BytesPointer(BufferPointer):
+    """Type class for pointers to :code:`Omnisci Bytes` structure."""
+
+
+class Bytes(Buffer):
+    pass
+
+
+@datamodel.register_default(BytesPointer)
+class BytesPointerModel(BufferPointerModel):
+    pass
+
+
+def bytes_type_converter(obj):
+    """Return Type instance corresponding to Omnisci :code:`Bytes` type.
+
+    :code:`Omnisci Bytes` is defined as follows (using C++ syntax)::
+
+      struct Column {
+        char* ptr;
+        size_t sz;
+        bool is_null;
+      }
+
+    See :code:`buffer_type_converter` for details.
+    """
+    return buffer_type_converter(
+        obj, OmnisciBytesType, 'Bytes', BytesPointer,
+        extra_members=[typesystem.Type.fromstring('bool is_null')],
+        element_type='char').pointer()
+
+
+@extending.lower_builtin(Bytes, types.Integer)
+def omnisci_bytes_constructor(context, builder, sig, args):
+    return omnisci_buffer_constructor(context, builder, sig, args)
+
+
+@extending.type_callable(Bytes)
+def type_omnisci_bytes(context):
+    def typer(size):
+        atyp = bytes_type_converter('Bytes')
+        return atyp.tonumba()
+    return typer

--- a/rbc/omnisci_backend/omnisci_pipeline.py
+++ b/rbc/omnisci_backend/omnisci_pipeline.py
@@ -1,59 +1,23 @@
 from rbc.utils import get_version
-from llvmlite import ir as llvm_ir
-from .omnisci_array import builder_buffers, ArrayPointer
+from .omnisci_buffer import BufferMeta, free_omnisci_buffer
 if get_version('numba') >= (0, 49):
-    from numba.core import ir, extending, types
+    from numba.core import ir
     from numba.core.compiler import CompilerBase, DefaultPassBuilder
     from numba.core.compiler_machinery import FunctionPass, register_pass
     from numba.core.untyped_passes import IRProcessing
 else:
-    from numba import ir, extending, types
+    from numba import ir
     from numba.compiler import CompilerBase, DefaultPassBuilder
     from numba.compiler_machinery import FunctionPass, register_pass
     from numba.untyped_passes import IRProcessing
-
-int8_t = llvm_ir.IntType(8)
-int32_t = llvm_ir.IntType(32)
-int64_t = llvm_ir.IntType(64)
-void_t = llvm_ir.VoidType()
-
-
-@extending.intrinsic
-def free_omnisci_array(typingctx, ret):
-    sig = types.void(ret)
-
-    def codegen(context, builder, signature, args):
-        buffers = builder_buffers[builder]
-
-        # TODO: using stdlib `free` that works only for CPU. For CUDA
-        # devices, we need to use omniscidb provided deallocator.
-        free_fnty = llvm_ir.FunctionType(void_t, [int8_t.as_pointer()])
-        free_fn = builder.module.get_or_insert_function(free_fnty, name="free")
-
-        # We skip the ret pointer iff we're returning an Array
-        # otherwise, we free everything
-        if isinstance(ret, ArrayPointer):
-            [arg] = args
-            ptr = builder.load(builder.gep(arg, [int32_t(0), int32_t(0)]))
-            ptr = builder.bitcast(ptr, int8_t.as_pointer())
-            for ptr8 in buffers:
-                with builder.if_then(builder.icmp_signed('!=', ptr, ptr8)):
-                    builder.call(free_fn, [ptr8])
-        else:
-            for ptr8 in buffers:
-                builder.call(free_fn, [ptr8])
-
-        del builder_buffers[builder]
-
-    return sig, codegen
 
 
 # Register this pass with the compiler framework, declare that it will not
 # mutate the control flow graph and that it is not an analysis_only pass (it
 # potentially mutates the IR).
 @register_pass(mutates_CFG=False, analysis_only=False)
-class FreeOmnisciArray(FunctionPass):
-    _name = "free_omnisci_arrays"  # the common name for the pass
+class FreeOmnisciBuffer(FunctionPass):
+    _name = "free_omnisci_buffers"  # the common name for the pass
 
     def __init__(self):
         FunctionPass.__init__(self)
@@ -66,7 +30,7 @@ class FreeOmnisciArray(FunctionPass):
         for blk in func_ir.blocks.values():
             for stmt in blk.find_insts(ir.Assign):
                 if isinstance(stmt.value, ir.FreeVar) \
-                   and stmt.value.name == 'Array':
+                   and stmt.value.name in BufferMeta.class_names:
                     break
             else:
                 continue
@@ -79,8 +43,8 @@ class FreeOmnisciArray(FunctionPass):
             scope = blk.scope
             for ret in blk.find_insts(ir.Return):
 
-                name = 'free_omnisci_array_fn'
-                value = ir.Global(name, free_omnisci_array, loc)
+                name = 'free_omnisci_buffer_fn'
+                value = ir.Global(name, free_omnisci_buffer, loc)
                 target = scope.make_temp(loc)
                 stmt = ir.Assign(value, target, loc)
                 blk.insert_before_terminator(stmt)
@@ -103,7 +67,7 @@ class OmnisciCompilerPipeline(CompilerBase):
         # namely the "nopython" pipeline
         pm = DefaultPassBuilder.define_nopython_pipeline(self.state)
         # Add the new pass to run after IRProcessing
-        pm.add_pass_after(FreeOmnisciArray, IRProcessing)
+        pm.add_pass_after(FreeOmnisciBuffer, IRProcessing)
         # finalize
         pm.finalize()
         # return as an iterable, any number of pipelines may be defined!

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -718,7 +718,6 @@ class RemoteOmnisci(RemoteJIT):
 
         consumed_index = 0
         name = caller.func.__name__
-        type_to_extarg = self.type_to_extarg
         for i, a in enumerate(orig_sig[1]):
             annot = a.annotation()
             _sizer = annot.get('sizer', unspecified)
@@ -735,23 +734,23 @@ class RemoteOmnisci(RemoteJIT):
                 sizer = _sizer
 
             if isinstance(a, OmnisciCursorType):
-                sqlArgTypes.append(type_to_extarg('Cursor'))
+                sqlArgTypes.append(self.type_to_extarg('Cursor'))
                 for a_ in a.as_consumed_args:
                     assert not isinstance(
                         a_, OmnisciOutputColumnType), (a_)
-                    inputArgTypes.append(type_to_extarg(a_))
+                    inputArgTypes.append(self.type_to_extarg(a_))
                     consumed_index += 1
             else:
                 if isinstance(a, OmnisciOutputColumnType):
                     if self.version < (5, 5):
-                        atype = type_to_extarg(a)
+                        atype = self.type_to_extarg(a)
                     else:
-                        atype = type_to_extarg(a[0][0])
+                        atype = self.type_to_extarg(a[0][0])
                     outputArgTypes.append(atype)
                 else:
-                    atype = type_to_extarg(a)
+                    atype = self.type_to_extarg(a)
                     if isinstance(a, OmnisciColumnType):
-                        sqlArgTypes.append(type_to_extarg('Cursor'))
+                        sqlArgTypes.append(self.type_to_extarg('Cursor'))
                         inputArgTypes.append(atype)
                     else:
                         sqlArgTypes.append(atype)
@@ -911,7 +910,6 @@ class RemoteOmnisci(RemoteJIT):
                     llvm_function_names.append(f.name)
 
                 device_ir_map[device] = str(llvm_module)
-                # print(device_ir_map[device])
                 skipped_names = []
                 for fid, udf in udfs_map.items():
                     if fid in succesful_fids:

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -924,13 +924,18 @@ class RemoteOmnisci(RemoteJIT):
                         udtfs.append(udtf)
                     else:
                         skipped_names.append(udtf.name)
-
+                if self.debug:
+                    print(f'Skipping: {", ".join(skipped_names)}')
         # Make sure that all registered functions have
         # implementations, otherwise, we will crash the server.
         for f in udtfs:
             assert f.name in llvm_function_names
         for f in udfs:
             assert f.name in llvm_function_names
+
+        if self.debug:
+            names = ", ".join([f.name for f in udfs] + [f.name for f in udtfs])
+            print(f'Registering: {names}')
 
         self.set_last_compile(device_ir_map)
         return self.thrift_call(

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -331,7 +331,6 @@ class TargetInfo(object):
           Return True when `desired_devices` is None or when the
           target device name is listed in `desired_devices`.
           Otherwise, return False.
-
         """
         if desired_devices is None:
             return True

--- a/rbc/tests/test_omnisci_text.py
+++ b/rbc/tests/test_omnisci_text.py
@@ -1,0 +1,144 @@
+import os
+from collections import defaultdict
+import pytest
+
+rbc_omnisci = pytest.importorskip('rbc.omniscidb')
+available_version, reason = rbc_omnisci.is_available()
+if available_version and available_version < (5, 5):
+    reason = ("test file requires omniscidb version 5.5+ with bytes support"
+              "(got %s)" % (available_version, ))
+    available_version = None
+
+pytestmark = pytest.mark.skipif(not available_version, reason=reason)
+
+
+@pytest.fixture(scope='module')
+def omnisci():
+    config = rbc_omnisci.get_client_config(debug=not True)
+    m = rbc_omnisci.RemoteOmnisci(**config)
+    table_name = os.path.splitext(os.path.basename(__file__))[0]
+    m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
+
+    sqltypes = ['TEXT ENCODING DICT', 'TEXT ENCODING DICT(16)', 'TEXT ENCODING DICT(8)',
+                'TEXT[] ENCODING DICT(32)', 'TEXT ENCODING NONE', 'TEXT ENCODING NONE', 'INT[]']
+    colnames = ['t4', 't2', 't1', 's', 'n', 'n2', 'i4']
+    table_defn = ',\n'.join('%s %s' % (n, t)
+                            for t, n in zip(sqltypes, colnames))
+    m.sql_execute(
+        'CREATE TABLE IF NOT EXISTS {table_name} ({table_defn});'
+        .format(**locals()))
+
+    data = defaultdict(list)
+    for i in range(5):
+        for j, n in enumerate(colnames):
+            if n in ['t4', 't2']:
+                data[n].append(['foofoo', 'bar', 'fun', 'bar', 'foo'][i])
+            if n in ['t1', 'n']:
+                data[n].append(['fun', 'bar', 'foo', 'barr', 'foooo'][i])
+            elif n == 's':
+                data[n].append([['foo', 'bar'], ['fun', 'bar'], ['foo']][i % 3])
+            elif n == 'n2':
+                data[n].append(['1', '12', '123', '1234', '12345'][i])
+            elif n == 'i4':
+                data[n].append(list(range(i+1)))
+
+    m.load_table_columnar(table_name, **data)
+    m.table_name = table_name
+    yield m
+    try:
+        m.sql_execute('DROP TABLE IF EXISTS {table_name}'.format(**locals()))
+    except Exception as msg:
+        print('%s in deardown' % (type(msg)))
+
+
+def test_table_data(omnisci):
+    omnisci.reset()
+
+    descr, result = omnisci.sql_execute(
+        'select t4, t2, t1, s, n from {omnisci.table_name}'.format(**locals()))
+    result = list(result)
+
+    assert result == [('foofoo', 'foofoo', 'fun', ['foo', 'bar'], 'fun'),
+                      ('bar', 'bar', 'bar', ['fun', 'bar'], 'bar'),
+                      ('fun', 'fun', 'foo', ['foo'], 'foo'),
+                      ('bar', 'bar', 'barr', ['foo', 'bar'], 'barr'),
+                      ('foo', 'foo', 'foooo', ['fun', 'bar'], 'foooo')]
+
+
+def test_bytes_len(omnisci):
+    omnisci.reset()
+
+    @omnisci('int32(Bytes, Bytes)')
+    def mystrlen(s, s2):
+        return len(s) * 100 + len(s2)
+
+    sql_query_expected = f"select length(n) * 100 + length(n2) from {omnisci.table_name}"
+    sql_query = f"select mystrlen(n, n2) from {omnisci.table_name}"
+
+    descr, result_expected = omnisci.sql_execute(sql_query_expected)
+    result_expected = list(result_expected)
+    descr, result = omnisci.sql_execute(sql_query)
+    result = list(result)
+
+    assert result == result_expected
+
+
+def test_bytes_ord(omnisci):
+    omnisci.reset()
+
+    @omnisci('int64(Bytes, int64)')
+    def myord(s, i):
+        return s[i] if i < len(s) else 0
+
+    sql_query_data = f"select n from {omnisci.table_name}"
+    descr, data = omnisci.sql_execute(sql_query_data)
+    data = list(data)
+
+    for i in range(5):
+        result_expected = [(ord(d[0][i]) if i < len(d[0]) else 0, ) for d in data]
+        sql_query = f"select myord(n, {i}) from {omnisci.table_name}"
+        descr, result = omnisci.sql_execute(sql_query)
+        result = list(result)
+        assert result == result_expected
+
+
+def test_bytes_return(omnisci):
+    omnisci.reset()
+
+    from rbc.omnisci_backend import Bytes
+
+    @omnisci('Bytes(int32, int32)')
+    def make_abc(first, n):
+        r = Bytes(n)
+        for i in range(n):
+            r[i] = first + i
+        return r
+
+    sql_query = f"select make_abc(97, 10)"
+    descr, result = omnisci.sql_execute(sql_query)
+    result = list(result)
+
+    assert result == [('abcdefghij', )]
+
+
+def test_bytes_upper(omnisci):
+    omnisci.reset()
+
+    from rbc.omnisci_backend import Bytes
+
+    @omnisci('Bytes(Bytes)')
+    def myupper(s):
+        r = Bytes(len(s))
+        for i in range(len(s)):
+            c = s[i]
+            if c >= 97 and c <= 122:
+                c = c - 32
+            r[i] = c
+        return r
+
+    sql_query = f"select n, myupper(n) from {omnisci.table_name}"
+    descr, result = omnisci.sql_execute(sql_query)
+    result = list(result)
+
+    for n, u in result:
+        assert n.upper() == u

--- a/rbc/tests/test_omnisci_text.py
+++ b/rbc/tests/test_omnisci_text.py
@@ -114,7 +114,7 @@ def test_bytes_return(omnisci):
             r[i] = first + i
         return r
 
-    sql_query = f"select make_abc(97, 10)"
+    sql_query = "select make_abc(97, 10)"
     descr, result = omnisci.sql_execute(sql_query)
     result = list(result)
 

--- a/rbc/tests/test_omnisci_text.py
+++ b/rbc/tests/test_omnisci_text.py
@@ -31,6 +31,7 @@ def omnisci():
     data = defaultdict(list)
     for i in range(5):
         for j, n in enumerate(colnames):
+            # todo: to check is_null, use empty string
             if n in ['t4', 't2']:
                 data[n].append(['foofoo', 'bar', 'fun', 'bar', 'foo'][i])
             if n in ['t1', 'n']:

--- a/rbc/tests/test_omnisci_text.py
+++ b/rbc/tests/test_omnisci_text.py
@@ -87,7 +87,7 @@ def test_bytes_len(omnisci):
 def test_bytes_ord(omnisci):
     omnisci.reset()
 
-    @omnisci('int64(Bytes, int64)')
+    @omnisci('int64(Bytes, int32)', devices=['gpu', 'cpu'])
     def myord(s, i):
         return s[i] if i < len(s) else 0
 


### PR DESCRIPTION
As in title.

In addition:
- Introduce process_callable method that enables detecting user errors when not importing Array and other types
- Continue moving Array features to Buffer
- Various clean ups
- Introduce `devices` kw argument to remotejit decorator so that the desired target devices can be specified manually.

Requires: https://github.com/omnisci/omniscidb-internal/pull/5017

Related to #192 