### PR TITLE
Introduce TargetInfo.llvm_version property.

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -83,8 +83,10 @@ class JITRemoteCPUCodegen(codegen.JITCPUCodegen):
 
     def _get_host_cpu_features(self):
         features = self.target_info.device_features
-        server_llvm_version = self.target_info.llvm_version[0]
-        client_llvm_version = llvm.llvm_version_info[0]
+        server_llvm_version = self.target_info.llvm_version
+        if server_llvm_version is None:
+            return ''
+        client_llvm_version = llvm.llvm_version_info
 
         # See https://github.com/xnd-project/rbc/issues/45
         remove_features = {
@@ -94,7 +96,7 @@ class JITRemoteCPUCodegen(codegen.JITCPUCodegen):
                       'amx-tile', 'amx-bf16', 'serialize', 'amx-int8',
                       'avx512vp2intersect', 'cx8', 'enqcmd', 'avx512bf16'],
             (9, 8): ['cx8', 'enqcmd', 'avx512bf16'],
-        }.get((server_llvm_version, client_llvm_version), [])
+        }.get((server_llvm_version[0], client_llvm_version[0]), [])
         for f in remove_features:
             features = features.replace('+' + f, '').replace('-' + f, '')
         return features

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -668,6 +668,9 @@ class RemoteOmnisci(RemoteJIT):
             version_str = '.'.join(map(str, self.version[:3])) + self.version[3]
             target_info.set('software', f'OmnisciDB {version_str}')
 
+            llvm_version = device_params.get('llvm_version')
+            if llvm_version is not None:
+                target_info.set('llvm_version', tuple(map(int, llvm_version.split('.'))))
         return targets
 
     @property

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -180,7 +180,8 @@ class TargetInfo(object):
         """
         supported_keys = ('name', 'triple', 'datalayout', 'features', 'bits',
                           'compute_capability', 'count', 'threads', 'cores',
-                          'has_cpython', 'has_numba', 'driver', 'software')
+                          'has_cpython', 'has_numba', 'driver', 'software',
+                          'llvm_version')
         if prop not in supported_keys:
             print(f'rbc.{type(self).__name__}:'
                   f' unsupported property {prop}={value}.')
@@ -302,6 +303,12 @@ class TargetInfo(object):
         """Check if target supports Python C/API symbols
         """
         return self.info.get('has_cpython', False)
+
+    @property
+    def llvm_version(self):
+        """Return target system LLVM versions tuple.
+        """
+        return self.info.get('llvm_version')
 
     # TODO: info may also contain: count, threads, cores
 


### PR DESCRIPTION
Requires omniscidb-internal https://github.com/omnisci/omniscidb-internal/pull/5026 to enable the functionality as in the title.

This feature allows comparing the host and server LLVM versions in order to disable some CPU features when the server's LLVM version is higher, otherwise llvmlite will show some annoying warnings such as:
```
'-tsxldtrk' is not a recognized feature for this target (ignoring feature)
```