### PR TITLE
Change pytest.raises match message depending on omniscidb version

### DIFF
--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -544,10 +544,14 @@ def test_overload(omnisci, step):
         result = list(result)
         assert result[0][0] == 32
     else:
+        if available_version <= (5, 5):
+            match_msg = r".*Function overloaded_udtf\(COLUMN<FLOAT>, INTEGER\) not supported"
+        else:
+            match_msg = (r".*Could not bind overloaded_udtf\(COLUMN<FLOAT>, INTEGER\)"
+                         r" to any CPU UDTF implementation.")
         with pytest.raises(
                 Exception,
-                match=(r".*Function overloaded_udtf\(COLUMN<FLOAT>, INTEGER\)"
-                       " not supported")):
+                match=match_msg):
             descr, result = omnisci.sql_execute(sql_query)
 
     sql_query = ('select * from table(overloaded_udtf(cursor('
@@ -557,10 +561,14 @@ def test_overload(omnisci, step):
         result = list(result)
         assert result[0][0] == 132
     else:
+        if available_version <= (5, 5):
+            match_msg = r".*Function overloaded_udtf\(COLUMN<FLOAT>, INTEGER\) not supported"
+        else:
+            match_msg = (r".*Could not bind overloaded_udtf\(COLUMN<FLOAT>,"
+                         r" COLUMN<FLOAT>, INTEGER\) to any CPU UDTF implementation")
         with pytest.raises(
                 Exception,
-                match=(r".*Function overloaded_udtf\(COLUMN<FLOAT>,"
-                       r" COLUMN<FLOAT>, INTEGER\) not supported")):
+                match=match_msg):
             descr, result = omnisci.sql_execute(sql_query)
 
 


### PR DESCRIPTION
The error message when there is not a match changed in OmniSciDB 5.6. This small PR updates RBC to work with this change.