### PR TITLE
Restore allocate_varlen_buffer

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -420,9 +420,9 @@ def compile_to_LLVM(functions_and_signatures,
         for func, signatures in functions_and_signatures:
             for fid, sig in signatures.items():
                 fname = compile_instance(func, sig, target_info, typing_context,
-                                        target_context, pipeline_class,
-                                        main_library,
-                                        debug=debug)
+                                         target_context, pipeline_class,
+                                         main_library,
+                                         debug=debug)
                 if fname is not None:
                     succesful_fids.append(fid)
                     function_names.append(fname)

--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -170,9 +170,8 @@ def omnisci_buffer_constructor(context, builder, sig, args):
 
     alloc_fnty = ir.FunctionType(int8_t.as_pointer(), [int64_t, int64_t])
 
-    # TODO: use omnisci alloc function instead of calloc, see rbc issue 87
     alloc_fn = builder.module.get_or_insert_function(
-        alloc_fnty, name="calloc")
+        alloc_fnty, name="allocate_varlen_buffer")
     ptr8 = builder.call(alloc_fn, [element_count, element_size])
     # remember possible temporary allocations so that when leaving a
     # UDF/UDTF, these will be deallocated, see omnisci_pipeline.py.


### PR DESCRIPTION
Solves gh-87

In this PR we're doing two things:
1. Remove target_info argument from RemoteJIT* classes
2. Hackish way to prevent numba from calling _ensure_finalize
3. Replace "calloc" by "allocate_varlen_buffer"

~PR is currently segfaulting in test `test_omnisci_math::positive`:~

```
~pytest rbc/tests/test_omnisci_math.py -k 'positive'~
```

cc @pearu 