### PR TITLE
Implement templates support and make custom type a fundamental type of RBC typesystem

### DIFF
--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -5,6 +5,7 @@ __all__ = ['RemoteJIT', 'Signature', 'Caller']
 
 import os
 import inspect
+import warnings
 from . import irtools
 from .typesystem import Type, get_signature
 from .thrift import Server, Dispatcher, dispatchermethod, Data, Client
@@ -104,7 +105,8 @@ class Signature(object):
     def local(self):
         sig = Signature(self.remotejit.local)
         sig.signatures.extend(self.signatures)
-        # sig.signature_templates.update(self.signature_templates)
+        assert not self.signature_devices
+        assert not self.signature_templates
         return sig
 
     def __str__(self):
@@ -243,7 +245,7 @@ class Signature(object):
             templates = self.signature_templates.get(sig, {})
             sig = Type.fromobject(sig)
             if not sig.is_complete:
-                print('Ignore incomplete type: ', sig)
+                warnings.warn(f'Incomplete signature {sig} will be ignored')
                 continue
             if not sig.is_function:
                 raise ValueError(

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -80,7 +80,6 @@ class TargetInfo(object):
         """
         self.name = name
         self.strict = strict
-        self.custom_type_converters = []
         self.info = {}
         self.type_sizeof = {}
         self._supported_libraries = set()  # libfuncs.Library instances
@@ -389,28 +388,3 @@ class TargetInfo(object):
             return ctypes.sizeof(t)
         raise NotImplementedError(
             f"{type(self).__name__}[{self.name},{self.triple}].sizeof({t!r})")
-
-    def add_converter(self, converter):
-        """Add custom type converter.
-
-        Custom type converters are called on non-concrete atomic
-        types.
-
-        Parameters
-        ----------
-        converter : callable
-          Specify a function with signature `converter(target_info,
-          obj)` that returns `Type` instance corresponding to
-          `obj`. If the conversion is unsuccesful, the `converter`
-          returns `None` so that other converter functions could be
-          tried.
-        """
-        self.custom_type_converters.append(converter)
-
-    def custom_type(self, t):
-        """Return custom type of an object.
-        """
-        for converter in self.custom_type_converters:
-            r = converter(t)
-            if r is not None:
-                return r

--- a/rbc/tests/test_omnisci_column_arguments.py
+++ b/rbc/tests/test_omnisci_column_arguments.py
@@ -81,7 +81,7 @@ def define(omnisci):
                           'cursor(i4,i8);f8', 'cursor(i4,i8);cursor(f8,f4)',
                           'cursor(i4,i8,f8,f4)'])
 def test_copy(omnisci, inputs):
-    omnisci.require_version((5, 6), 'Requires omniscidb-internal PR 5134')
+    omnisci.require_version((5, 7), 'Requires omniscidb-internal PR 5134')
 
     groups = inputs.split(';')
     table_names = [f'{omnisci.table_name}'] * len(groups)

--- a/rbc/tests/test_omnisci_column_arguments.py
+++ b/rbc/tests/test_omnisci_column_arguments.py
@@ -81,7 +81,7 @@ def define(omnisci):
                           'cursor(i4,i8);f8', 'cursor(i4,i8);cursor(f8,f4)',
                           'cursor(i4,i8,f8,f4)'])
 def test_copy(omnisci, inputs):
-    omnisci.require_version((5, 7), 'Requires omniscidb-internal PR 5134')
+    omnisci.require_version((5, 6), 'Requires omniscidb-internal PR 5134')
 
     groups = inputs.split(';')
     table_names = [f'{omnisci.table_name}'] * len(groups)

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -575,12 +575,8 @@ def test_overload_uniform(omnisci):
     omnisci.reset()
     omnisci.register()
 
-    @omnisci('int32(Column<double>, RowMultiplier, OutputColumn<double>)',
-             'int32(Column<float>, RowMultiplier, OutputColumn<float>)',
-             'int32(Column<int64>, RowMultiplier, OutputColumn<int64>)',
-             'int32(Column<int32>, RowMultiplier, OutputColumn<int32>)',
-             'int32(Column<int16>, RowMultiplier, OutputColumn<int16>)',
-             'int32(Column<int8>, RowMultiplier, OutputColumn<int8>)')  # noqa: E501, F811
+    @omnisci('int32(Column<T>, RowMultiplier, OutputColumn<T>)',
+             T=['double', 'float', 'int64', 'int32', 'int16', 'int8'])
     def mycopy(x, m, y):  # noqa: E501, F811
         for i in range(len(x)):
             y[i] = x[i]


### PR DESCRIPTION
As in title.

Having custom type as a fundamental type of typesystem makes introducing new types much easier: one has to derive a custom type from `Type` and implement the `tonumba` method as a minimum.

Resolves issue #220.