### PR TITLE
Support remote access and conversion of pointer values of scalar, struct, and pointer types

### DIFF
--- a/rbc/external.py
+++ b/rbc/external.py
@@ -128,7 +128,7 @@ class External:
                 # get the correct signature and function name for the current device
                 atypes = tuple(map(Type.fromobject, args))
                 t = self.obj.match_signature(atypes)
-
+                TargetInfo().add_external(t.name)
                 if self.obj.lowering:
                     codegen = self.obj.get_codegen()
                     extending.lower_builtin(self.key, *t.tonumba().args)(codegen)

--- a/rbc/external.py
+++ b/rbc/external.py
@@ -24,7 +24,8 @@ class External:
         ts = defaultdict(list)
         key = None
         for signature in args:
-            t = Type.fromobject(signature)
+            with TargetInfo.dummy():
+                t = Type.fromobject(signature)
             if not t.is_function:
                 raise ValueError("signature must represent a function type")
 

--- a/rbc/externals/macros.py
+++ b/rbc/externals/macros.py
@@ -14,7 +14,7 @@ Casts:
   intp, voidptr to/from T*, T**, ..., T************* where T is a scalar type.
 """
 
-__all__ = ['sizeof']
+__all__ = ['sizeof', 'cast']
 
 from llvmlite import ir
 from numba.core import extending, imputils, typing, typeconv

--- a/rbc/externals/macros.py
+++ b/rbc/externals/macros.py
@@ -1,0 +1,111 @@
+"""This module provides the following tools:
+
+Intrinsics:
+
+  sizeof(<numba.types.TypeRef|Type instance>)
+  cast(<numba.types.voidptr instance>, <numba.types.TypeRef|StringLiteral instance>)
+
+Methods:
+
+  <numba.types.voidptr instance>.cast(<numba.types.TypeRef|StringLiteral instance>)
+
+Casts:
+
+  intp, voidptr to/from T*, T**, ..., T************* where T is a scalar type.
+"""
+
+__all__ = ['sizeof']
+
+from llvmlite import ir
+from numba.core import extending, imputils, typing, typeconv
+from numba.core import types as nb_types
+from rbc.typesystem import Type
+
+
+typing_registry = typing.templates.Registry()
+lowering_registry = imputils.Registry()
+
+
+@extending.intrinsic
+def sizeof(typingctx, arg_type):
+    """Return sizeof type.
+    """
+    if isinstance(arg_type, nb_types.TypeRef):
+        arg_val_type = arg_type.key
+    elif isinstance(arg_type, nb_types.Type):
+        arg_val_type = arg_type
+    else:
+        return
+    sig = nb_types.int32(arg_type)
+
+    def codegen(context, builder, signature, args):
+        value_type = context.get_value_type(arg_val_type)
+        size = context.get_abi_sizeof(value_type)
+        return ir.Constant(ir.IntType(32), size)
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def cast(typingctx, ptr, typ):
+    """Cast pointer value to any pointer type.
+    """
+    if isinstance(typ, nb_types.StringLiteral):
+        dtype = Type.fromstring(typ.literal_value)
+    elif isinstance(typ, nb_types.TypeRef):
+        dtype = Type.fromnumba(typ.key)
+    else:
+        return
+    assert dtype.is_pointer
+    sig = dtype.tonumba()(ptr, typ)
+
+    def codegen(context, builder, signature, args):
+        return builder.bitcast(args[0], dtype.tollvmir())
+
+    return sig, codegen
+
+
+@extending.overload_method(type(nb_types.voidptr), 'cast')
+def voidptr_cast_to_any(ptr, typ):
+    """Convenience method for casting voidptr to any pointer type.
+    """
+    if isinstance(ptr, type(nb_types.voidptr)):
+        if isinstance(typ, (nb_types.TypeRef, nb_types.StringLiteral)):
+            def impl(ptr, typ):
+                return cast(ptr, typ)
+            return impl
+
+
+@lowering_registry.lower_cast(nb_types.intp, nb_types.CPointer)
+def impl_intp_to_T_star(context, builder, fromty, toty, value):
+    return builder.inttoptr(value, Type.fromnumba(toty).tollvmir())
+
+
+@lowering_registry.lower_cast(nb_types.CPointer, nb_types.intp)
+@lowering_registry.lower_cast(nb_types.RawPointer, nb_types.intp)
+def impl_T_star_to_intp(context, builder, fromty, toty, value):
+    return builder.ptrtoint(value, ir.IntType(toty.bitwidth))
+
+
+@lowering_registry.lower_cast(nb_types.CPointer, nb_types.RawPointer)
+@lowering_registry.lower_cast(nb_types.RawPointer, nb_types.CPointer)
+def impl_T_star_to_T_star(context, builder, fromty, toty, value):
+    return builder.bitcast(value, Type.fromnumba(toty).tollvmir())
+
+
+scalar_types = [getattr(nb_types, typename) for typename in
+                ['int64', 'int32', 'int16', 'int8',
+                 'uint64', 'uint32', 'uint16', 'uint8',
+                 'float32', 'float64', 'boolean']]
+pointer_value_types = [nb_types.intp, nb_types.voidptr]
+pointer_types = [nb_types.CPointer(s) for s in scalar_types] + [nb_types.voidptr]
+for p1 in pointer_value_types:
+    for p2 in pointer_types:
+        # ANSI C requires 12 as a maximum supported pointer level.
+        for i in range(12):
+            if p1 != p2:
+                typeconv.rules.default_type_manager.set_compatible(
+                    p1, p2, typeconv.Conversion.safe)
+                typeconv.rules.default_type_manager.set_compatible(
+                    p2, p1, typeconv.Conversion.safe)
+            p2 = nb_types.CPointer(p2)

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -11,7 +11,7 @@ from .targetinfo import TargetInfo
 from .utils import get_version
 from .errors import UnsupportedError
 from .typesystem import Type
-from . import libfuncs
+from . import libfuncs, structure_type
 
 if get_version('numba') >= (0, 49):
     from numba.core import codegen, cpu, compiler_lock, \
@@ -138,8 +138,8 @@ class JITRemoteCodegen(codegen.JITCPUCodegen):
 class JITRemoteTypingContext(typing.Context):
     def load_additional_registries(self):
         from rbc.externals import math
-
         self.install_registry(math.typing_registry)
+        self.install_registry(structure_type.typing_registry)
         super().load_additional_registries()
 
 
@@ -154,8 +154,8 @@ class JITRemoteTargetContext(cpu.CPUContext):
 
     def load_additional_registries(self):
         from rbc.externals import math
-
         self.install_registry(math.lowering_registry)
+        self.install_registry(structure_type.lowering_registry)
         super().load_additional_registries()
 
     def get_executable(self, library, fndesc, env):
@@ -355,7 +355,7 @@ def compile_to_LLVM(functions_and_signatures,
 
     """
     target_desc = registry.cpu_target
-    if target_info is None:
+    if target_info is None and 0:
         # RemoteJIT
         target_info = TargetInfo.host()
         typing_context = target_desc.typing_context

--- a/rbc/omnisci_backend/omnisci_array.py
+++ b/rbc/omnisci_backend/omnisci_array.py
@@ -32,9 +32,6 @@ class OmnisciArrayType(OmnisciBufferType):
         return ('bool is_null',)
 
 
-typesystem.Type.alias(Array='OmnisciArrayType')
-
-
 ArrayPointer = BufferPointer
 
 

--- a/rbc/omnisci_backend/omnisci_bytes.py
+++ b/rbc/omnisci_backend/omnisci_bytes.py
@@ -31,9 +31,6 @@ class OmnisciBytesType(OmnisciBufferType):
         return ('bool is_null',)
 
 
-typesystem.Type.alias(Bytes='OmnisciBytesType<char8>')
-
-
 BytesPointer = BufferPointer
 
 

--- a/rbc/omnisci_backend/omnisci_column.py
+++ b/rbc/omnisci_backend/omnisci_column.py
@@ -131,12 +131,3 @@ class OmnisciCursorType(typesystem.Type):
     @property
     def as_consumed_args(self):
         return self[0]
-
-
-typesystem.Type.alias(
-    Cursor='OmnisciCursorType',
-    Column='OmnisciColumnType',
-    OutputColumn='OmnisciOutputColumnType',
-    RowMultiplier='int32|sizer=RowMultiplier',
-    ConstantParameter='int32|sizer=ConstantParameter',
-    Constant='int32|sizer=Constant')

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -218,6 +218,17 @@ class RemoteOmnisci(RemoteJIT):
     multiplexed = False
     mangle_prefix = ''
 
+    typesystem_aliases = dict(
+        bool='bool8',
+        Array='OmnisciArrayType',
+        Bytes='OmnisciBytesType<char8>',
+        Cursor='OmnisciCursorType',
+        Column='OmnisciColumnType',
+        OutputColumn='OmnisciOutputColumnType',
+        RowMultiplier='int32|sizer=RowMultiplier',
+        ConstantParameter='int32|sizer=ConstantParameter',
+        Constant='int32|sizer=Constant')
+
     def __init__(self,
                  user='admin',
                  password='HyperInteractive',
@@ -628,8 +639,11 @@ class RemoteOmnisci(RemoteJIT):
             ext_arguments_map['Array<bool>'] = typemap[
                 'TExtArgumentType']['ArrayInt8']
 
+        ext_arguments_map['bool8'] = ext_arguments_map['bool']
+
         for ptr_type, T in [
                 ('bool', 'bool'),
+                ('bool8', 'bool'),
                 ('int8', 'int8_t'),
                 ('int16', 'int16_t'),
                 ('int32', 'int32_t'),
@@ -902,6 +916,10 @@ class RemoteOmnisci(RemoteJIT):
             atypes, rtype)
 
     def register(self):
+        with typesystem.Type.alias(**self.typesystem_aliases):
+            return self._register()
+
+    def _register(self):
         if self.have_last_compile:
             return
 

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -752,7 +752,7 @@ class DispatcherRJIT(Dispatcher):
                     member_values = [t.toctypes()(value[i]) for i, t in enumerate(typ)]
                 else:
                     member_values = [t.toctypes()(getattr(value, t.name)) for t in typ]
-                ctypes_arguments.append(typ.toctypes()(*member_values))
+                ctypes_arguments.extend(member_values)
             elif typ.is_pointer:
                 if isinstance(value, ctypes.c_void_p):
                     value = ctypes.cast(value, typ.toctypes())

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -748,7 +748,10 @@ class DispatcherRJIT(Dispatcher):
             if typ.is_custom:
                 typ = typ.get_struct_type()
             if typ.is_struct:
-                member_values = [getattr(value, t.name) for t in typ]
+                if isinstance(value, tuple):
+                    member_values = [t.toctypes()(value[i]) for i, t in enumerate(typ)]
+                else:
+                    member_values = [t.toctypes()(getattr(value, t.name)) for t in typ]
                 ctypes_arguments.append(typ.toctypes()(*member_values))
             elif typ.is_pointer:
                 if isinstance(value, ctypes.c_void_p):

--- a/rbc/remotejit.thrift
+++ b/rbc/remotejit.thrift
@@ -5,4 +5,5 @@ service remotejit {
     map<string, string> targets() throws (1: Exception e),
     bool compile(1: string name, 2: string signatures, 3: string ir) throws (1: Exception e),
     Data call(1: string fullname, 2: Data arguments) throws (1: Exception e),
+    bool python(1: string statement) throws (1: Exception e),
 }

--- a/rbc/structure_type.py
+++ b/rbc/structure_type.py
@@ -1,16 +1,11 @@
+
+__all__ = ['StructureNumbaType', 'StructureNumbaPointerType', 'make_numba_struct']
+
 import operator
-from rbc.utils import get_version
 from llvmlite import ir
-from rbc.typesystem import Type
+from numba.core import datamodel, extending, types, imputils, typing, cgutils, typeconv
 
-if get_version('numba') >= (0, 49):
-    from numba.core import datamodel, extending, types, imputils, typing, cgutils, typeconv
-else:
-    from numba import datamodel, extending, types, typing, typeconv
-
-from numba.core.typing.templates import Registry
-
-typing_registry = Registry()
+typing_registry = typing.templates.Registry()
 lowering_registry = imputils.Registry()
 
 int8_t = ir.IntType(8)
@@ -179,3 +174,7 @@ def StructureNumbaPointerType_add(x, i):
 @lowering_registry.lower_cast(StructureNumbaPointerType, types.RawPointer)
 def impl_T_star_to_T_star(context, builder, fromty, toty, value):
     return builder.bitcast(value, Type.fromnumba(toty).tollvmir())
+
+
+if 1:
+    from rbc.typesystem import Type

--- a/rbc/structure_type.py
+++ b/rbc/structure_type.py
@@ -1,7 +1,7 @@
 from rbc.utils import get_version
 from llvmlite import ir
 if get_version('numba') >= (0, 49):
-    from numba.core import datamodel, extending, types, imputils, typing
+    from numba.core import datamodel, extending, types, imputils, typing, cgutils
 else:
     from numba import datamodel, extending, types, typing
 
@@ -20,7 +20,35 @@ fp64 = ir.DoubleType()
 
 
 class StructureNumbaType(types.Type):
-    pass_by_value = True
+    # pass_by_value = True
+    # return_as_first_argument = True  # use it only when deriving from types.PointerType
+
+    pass
+
+
+class StructureNumbaPointerType(types.Type):
+    """We are not deriving from CPointer because we may want to use
+    getitem for other purposes.
+    """
+    # pass_by_value = True
+    # return_as_first_argument = True  # use it only when deriving from types.PointerType
+    @property
+    def __typesystem_type__(self):
+        return self.dtype.origin.pointer()
+
+    def __init__(self, dtype):
+        self.dtype = dtype    # struct dtype
+        name = "(%s)*" % dtype
+        super().__init__(name)
+
+    @property
+    def key(self):
+        return self.dtype
+
+
+@datamodel.register_default(StructureNumbaPointerType)
+class StructureNumbaPointerTypeModel(datamodel.models.PointerModel):
+    pass
 
 
 @extending.infer_getattr
@@ -32,28 +60,60 @@ class StructAttribute(typing.templates.AttributeTemplate):
         return model.get_member_fe_type(attr)
 
 
+@extending.infer_getattr
+class StructPointerAttribute(typing.templates.AttributeTemplate):
+    key = StructureNumbaPointerType
+
+    def generic_resolve(self, typ, attr):
+        model = datamodel.default_manager.lookup(typ.dtype)
+        return model.get_member_fe_type(attr)
+
+
 @lowering_registry.lower_getattr_generic(StructureNumbaType)
 def StructureNumbaType_getattr_impl(context, builder, sig, struct, attr):
-    print(f'getattr_impl({sig=}, {struct=}, {attr=})')
+    # print(f'StructureNumbaType_getattr_impl({sig=}, {struct=}, {attr=})')
     model = datamodel.default_manager.lookup(sig)
     assert struct.opname == 'load'
     index = model.get_field_position(attr)
 
     ptr = builder.gep(struct.operands[0], [int32_t(0), int32_t(0)])
-    res = builder.load(builder.gep(ptr, [int32_t(index)]))
-    return res
-    return builder.load(builder.gep(struct.operands[0], [int32_t(0), int32_t(index)]))
+    return builder.load(builder.gep(ptr, [int32_t(index)]))
 
 
 @lowering_registry.lower_setattr_generic(StructureNumbaType)
 def StructureNumbaType_setattr_impl(context, builder, sig, args, attr):
-    print(f'setattr_impl({sig=}, {args=}, {attr=})')
+    # print(f'StructureNumbaType_setattr_impl({sig=}, {args=}, {attr=})')
     typ = sig.args[0]
     struct, value = args
-    print(f'{struct=} {value=}')
     model = datamodel.default_manager.lookup(typ)
     assert struct.opname == 'load'
     index = model.get_field_position(attr)
-    print(f'{builder=}')
     ptr = builder.gep(struct.operands[0], [int32_t(0), int32_t(index)])
     return builder.store(value, ptr)
+
+
+@lowering_registry.lower_getattr_generic(StructureNumbaPointerType)
+def StructureNumbaPointerType_getattr_impl(context, builder, sig, struct, attr):
+    # print(f'StructureNumbaPointerType_getattr_impl({sig=}, {struct=}, {attr=})')
+    typ = sig.dtype
+    model = datamodel.default_manager.lookup(typ)
+    assert struct.opname == 'load'
+    index = model.get_field_position(attr)
+    rawptr = cgutils.alloca_once_value(builder, value=struct)
+    struct = builder.load(builder.gep(rawptr, [int32_t(0)]))
+    return builder.load(builder.gep(
+        struct, [int32_t(0), int32_t(index)]))
+
+
+@lowering_registry.lower_setattr_generic(StructureNumbaPointerType)
+def StructureNumbaPointerType_setattr_impl(context, builder, sig, args, attr):
+    # print(f'StructureNumbaPointerType_setattr_impl({sig=}, {args=}, {attr=})')
+    typ = sig.args[0].dtype
+    struct, value = args
+    model = datamodel.default_manager.lookup(typ)
+    assert struct.opname == 'load'
+    index = model.get_field_position(attr)
+    rawptr = cgutils.alloca_once_value(builder, value=struct)
+    ptr = builder.load(rawptr)
+    buf = builder.load(builder.gep(ptr, [int32_t(0), int32_t(index)]))
+    builder.store(value, buf.operands[0])

--- a/rbc/structure_type.py
+++ b/rbc/structure_type.py
@@ -1,0 +1,59 @@
+from rbc.utils import get_version
+from llvmlite import ir
+if get_version('numba') >= (0, 49):
+    from numba.core import datamodel, extending, types, imputils, typing
+else:
+    from numba import datamodel, extending, types, typing
+
+from numba.core.typing.templates import Registry
+
+typing_registry = Registry()
+lowering_registry = imputils.Registry()
+
+
+int8_t = ir.IntType(8)
+int32_t = ir.IntType(32)
+int64_t = ir.IntType(64)
+void_t = ir.VoidType()
+fp32 = ir.FloatType()
+fp64 = ir.DoubleType()
+
+
+class StructureNumbaType(types.Type):
+    pass_by_value = True
+
+
+@extending.infer_getattr
+class StructAttribute(typing.templates.AttributeTemplate):
+    key = StructureNumbaType
+
+    def generic_resolve(self, typ, attr):
+        model = datamodel.default_manager.lookup(typ)
+        return model.get_member_fe_type(attr)
+
+
+@lowering_registry.lower_getattr_generic(StructureNumbaType)
+def StructureNumbaType_getattr_impl(context, builder, sig, struct, attr):
+    print(f'getattr_impl({sig=}, {struct=}, {attr=})')
+    model = datamodel.default_manager.lookup(sig)
+    assert struct.opname == 'load'
+    index = model.get_field_position(attr)
+
+    ptr = builder.gep(struct.operands[0], [int32_t(0), int32_t(0)])
+    res = builder.load(builder.gep(ptr, [int32_t(index)]))
+    return res
+    return builder.load(builder.gep(struct.operands[0], [int32_t(0), int32_t(index)]))
+
+
+@lowering_registry.lower_setattr_generic(StructureNumbaType)
+def StructureNumbaType_setattr_impl(context, builder, sig, args, attr):
+    print(f'setattr_impl({sig=}, {args=}, {attr=})')
+    typ = sig.args[0]
+    struct, value = args
+    print(f'{struct=} {value=}')
+    model = datamodel.default_manager.lookup(typ)
+    assert struct.opname == 'load'
+    index = model.get_field_position(attr)
+    print(f'{builder=}')
+    ptr = builder.gep(struct.operands[0], [int32_t(0), int32_t(index)])
+    return builder.store(value, ptr)

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -83,6 +83,10 @@ class TargetInfo(object):
         self.info = {}
         self.type_sizeof = {}
         self._supported_libraries = set()  # libfuncs.Library instances
+        self._userdefined_externals = set()
+
+    def add_external(self, *names):
+        self._userdefined_externals.update(names)
 
     def add_library(self, lib):
         if isinstance(lib, str):
@@ -96,6 +100,8 @@ class TargetInfo(object):
     def supports(self, name):
         """Return True if the target system defines symbol name.
         """
+        if name in self._userdefined_externals:
+            return True
         for lib in self._supported_libraries:
             if name in lib:
                 return True

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -130,20 +130,17 @@ class TargetInfo(object):
     def fromdict(cls, data):
         target_info = cls(data.get('name', 'somedevice'),
                           strict=data.get('strict', False))
-        target_info.info.update(data.get('info', {}))
-        target_info.type_sizeof.update(data.get('type_sizeof', {}))
-        for lib in data.get('libraries', []):
-            target_info.add_library(lib)
-        target_info.add_external(*data.get('externals', ()))
+        target_info.update(data)
         return target_info
 
-    def update(self, other):
+    def update(self, data):
         """Update target info using other target info data. Any existing data
         bit will be overwritten except the name and strict fields.
         """
-        data = other.todict()
+        if isinstance(data, type(self)):
+            data = data.todict()
         self.info.update(data.get('info', {}))
-        self.type_sizeof.update(data.get('info', {}))
+        self.type_sizeof.update(data.get('typeof_sizeof', {}))
         for lib in data.get('libraries', []):
             self.add_library(lib)
         self.add_external(*data.get('externals', []))
@@ -434,6 +431,7 @@ class TargetInfo(object):
             if t == 'char':
                 return 1  # IEC 9899
         if self.name == 'dummy':
+            # don't guess
             return
         if isinstance(t, str):
             if t == 'int':

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -204,6 +204,7 @@ class TargetInfo(object):
                 float=ctypes.c_float,
                 double=ctypes.c_double,
                 longdouble=ctypes.c_longdouble,
+                voidptr=ctypes.c_void_p
         ).items():
             target_info.type_sizeof[tname] = ctypes.sizeof(ctype)
 

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -1,19 +1,31 @@
 import atexit
 import pytest
 import sys
+import ctypes
+import numpy as np
 from rbc.remotejit import RemoteJIT, Signature, Caller
 from rbc.typesystem import Type
+from rbc.external import external
+from rbc.targetinfo import TargetInfo
 
 win32 = sys.platform == 'win32'
 
 
 @pytest.fixture(scope="module")
 def rjit(request):
-    rjit = RemoteJIT(debug=True)
-    rjit.start_server(background=True)
-    request.addfinalizer(rjit.stop_server)
-    atexit.register(rjit.stop_server)
+    local = False
+    rjit = RemoteJIT(debug=not True, local=local)
+    if not local:
+        rjit.start_server(background=True)
+        request.addfinalizer(rjit.stop_server)
+        atexit.register(rjit.stop_server)
     return rjit
+
+
+@pytest.fixture(scope="module")
+def ljit(request):
+    ljit = RemoteJIT(debug=not True, local=True)
+    return ljit
 
 
 def with_localjit(test_func):
@@ -302,3 +314,231 @@ def test_templates(ljit):
 
     check_normalized(ljit('T(U)', T=['i8', 'i4'], U=['MyClass3<T>']),
                      ljit('i8(MyClass3<int8>)', 'int4(MyClass3<i4>)'))
+
+
+scalar_pointer_types = ['int64', 'int32', 'int16', 'int8', 'float32', 'float64', 'bool', 'void']
+
+
+@pytest.mark.parametrize("T", scalar_pointer_types)
+@pytest.mark.parametrize("V", scalar_pointer_types)
+def test_scalar_pointer_conversion(rjit, T, V):
+    Type.alias(T=T, V=V, intp='int64')
+
+    # pointer-intp conversion
+
+    @rjit('T*(intp a)')
+    def i2p(a):
+        return a
+
+    @rjit('V*(intp a)')
+    def i2r(a):
+        return a
+
+    @rjit('intp(T* a)')
+    def p2i(a):
+        return a
+
+    @rjit('intp(V* a)')
+    def r2i(a):
+        return a
+
+    @rjit('T*(T* a)')
+    def p2p(a):
+        return a
+
+    @rjit('T*(V* a)')
+    def p2r(a):
+        return a
+
+    @rjit('V*(T* a)')
+    def r2p(a):
+        return a
+
+    # pointer artithmetics
+
+    @rjit('T*(T* a, intp i)')
+    def padd(a, i):
+        return a + i
+
+    @rjit('T*(T* a)')
+    def pincr(a):
+        return a + 1
+
+    if T == V:
+        i = 79
+        p = i2p(i)
+        assert not isinstance(p, int), (type(p), p)
+        assert ctypes.cast(p, ctypes.c_void_p).value == i
+        i2 = p2i(p)
+        assert i2 == i
+        p2 = p2p(p)
+        assert ctypes.cast(p2, ctypes.c_void_p).value == ctypes.cast(p, ctypes.c_void_p).value
+        assert p2i(padd(p, 2)) == i + 2
+        assert p2i(pincr(p)) == i + 1
+
+    if 'void' in [T, V]:
+        i = 85
+        r = i2r(i)
+        assert not isinstance(r, int), (type(r), r)
+
+        assert ctypes.cast(r, ctypes.c_void_p).value == i
+        p2 = r2p(r)
+        assert p2i(p2) == i
+        assert p2i(p2r(i2p(i))) == i
+
+    # double pointer-intp conversion
+
+    @rjit('T**(intp a)')
+    def i2pp(a):
+        return a
+
+    @rjit('V**(intp a)')
+    def i2rr(a):
+        return a
+
+    @rjit('intp(T** a)')
+    def pp2i(a):
+        return a
+
+    @rjit('intp(V** a)')
+    def rr2i(a):
+        return a
+
+    @rjit('T**(T** a)')
+    def pp2pp(a):
+        return a
+
+    @rjit('T**(T** a, intp i)')
+    def ppadd(a, i):
+        return a + i
+
+    @rjit('T**(T** a)')
+    def ppincr(a):
+        return a + 1
+
+    if T == V:
+        i = 89
+        pp = i2pp(i)
+        assert ctypes.cast(pp, ctypes.c_void_p).value == i
+        i2 = pp2i(pp)
+        assert i2 == i
+        pp2 = pp2pp(pp)
+        assert ctypes.cast(pp2, ctypes.c_void_p).value == ctypes.cast(pp, ctypes.c_void_p).value
+        assert pp2i(ppadd(pp, 2)) == i + 2
+        assert pp2i(ppincr(pp)) == i + 1
+
+    # double pointer-pointer conversion
+
+    @rjit('T**(T* a)')
+    def p2pp(a):
+        return a
+
+    @rjit('T*(T** a)')
+    def pp2p(a):
+        return a
+
+    # mixed pointer conversion requires void*
+
+    @rjit('T**(V* a)')
+    def r2pp(a):
+        return a
+
+    @rjit('V*(T** a)')
+    def pp2r(a):
+        return a
+
+    if T == V:
+        i = 99
+        p = i2p(i)
+        pp = p2pp(p)
+        assert pp2i(pp) == i
+        assert p2i(pp2p(pp)) == i
+
+    if V == 'void':
+        i = 105
+        assert r2i(pp2r(i2pp(i))) == i
+        assert pp2i(r2pp(i2r(i))) == i
+
+
+@pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
+def test_scalar_pointer_access_local(ljit, T):
+    Type.alias(T=T)
+
+    arr = np.array([1, 2, 3, 4], dtype=T)
+    arr2 = np.array([11, 12, 13, 14], dtype=T)
+
+    ptr = ctypes.c_void_p(arr.__array_interface__['data'][0])
+
+    @ljit('T(T* x, int i)')
+    def pitem(x, i):
+        return x[i]
+
+    @ljit('void(T* x, int i, T)')
+    def sitem(x, i, v):
+        x[i] = v
+
+    for i in range(len(arr)):
+        v = pitem(ptr, i)
+        assert v == arr[i]
+
+    for i in range(len(arr)):
+        sitem(ptr, i, arr2[i])
+
+    assert (arr == arr2).all()
+
+
+memory_managers = dict(
+    cstdlib=('void* calloc(size_t nmemb, size_t size)',
+             'void free(void* ptr)'),
+    PyMem_Raw=(
+        'void* PyMem_RawCalloc(size_t nmemb, size_t size)',
+        'void PyMem_RawFree(void* ptr)'),
+    PyMem=(
+        'void* PyMem_Calloc(size_t nmemb, size_t size)',
+        'void PyMem_Free(void* ptr)'),
+)
+
+
+@pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
+@pytest.mark.parametrize("memman", list(memory_managers))
+def test_scalar_pointer_access_remote(rjit, memman, T):
+    calloc_prototype, free_prototype = memory_managers[memman]
+
+    Type.alias(T=T)
+
+    arr = np.array([1, 2, 3, 4], dtype=T)
+    arr2 = np.array([11, 12, 13, 14], dtype=T)
+
+    with TargetInfo.host():  # TODO: can we eliminate this?
+        calloc = external(calloc_prototype)
+        free = external(free_prototype)
+
+    @rjit(calloc_prototype)
+    def rcalloc(nmemb, size):
+        return calloc(nmemb, size)
+
+    @rjit(free_prototype)
+    def rfree(ptr):
+        return free(ptr)
+
+    @rjit('T(T* x, int i)')
+    def pitem(x, i):
+        return x[i]
+
+    @rjit('void(T* x, int i, T)')
+    def sitem(x, i, v):
+        x[i] = v
+
+    ptr = rcalloc(arr.itemsize, len(arr))
+
+    assert ptr.value
+
+    for i in range(len(arr)):
+        sitem(ptr, i, arr[i])
+
+    for i in range(len(arr2)):
+        arr2[i] = pitem(ptr, i)
+
+    rfree(ptr)
+
+    assert (arr == arr2).all()

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -322,169 +322,170 @@ scalar_pointer_types = ['int64', 'int32', 'int16', 'int8', 'float32', 'float64',
 @pytest.mark.parametrize("T", scalar_pointer_types)
 @pytest.mark.parametrize("V", scalar_pointer_types)
 def test_scalar_pointer_conversion(rjit, T, V):
-    Type.alias(T=T, V=V, intp='int64')
+    with Type.alias(T=T, V=V, intp='int64'):
 
-    # pointer-intp conversion
+        # pointer-intp conversion
 
-    @rjit('T*(intp a)')
-    def i2p(a):
-        return a
+        @rjit('T*(intp a)')
+        def i2p(a):
+            return a
 
-    @rjit('V*(intp a)')
-    def i2r(a):
-        return a
+        @rjit('V*(intp a)')
+        def i2r(a):
+            return a
 
-    @rjit('intp(T* a)')
-    def p2i(a):
-        return a
+        @rjit('intp(T* a)')
+        def p2i(a):
+            return a
 
-    @rjit('intp(V* a)')
-    def r2i(a):
-        return a
+        @rjit('intp(V* a)')
+        def r2i(a):
+            return a
 
-    @rjit('T*(T* a)')
-    def p2p(a):
-        return a
+        @rjit('T*(T* a)')
+        def p2p(a):
+            return a
 
-    @rjit('T*(V* a)')
-    def p2r(a):
-        return a
+        @rjit('T*(V* a)')
+        def p2r(a):
+            return a
 
-    @rjit('V*(T* a)')
-    def r2p(a):
-        return a
+        @rjit('V*(T* a)')
+        def r2p(a):
+            return a
 
-    # pointer artithmetics
+        # pointer artithmetics
 
-    @rjit('T*(T* a, intp i)')
-    def padd(a, i):
-        return a + i
+        @rjit('T*(T* a, intp i)')
+        def padd(a, i):
+            return a + i
 
-    @rjit('T*(T* a)')
-    def pincr(a):
-        return a + 1
+        @rjit('T*(T* a)')
+        def pincr(a):
+            return a + 1
 
-    if T == V:
-        i = 79
-        p = i2p(i)
-        assert not isinstance(p, int), (type(p), p)
-        assert ctypes.cast(p, ctypes.c_void_p).value == i
-        i2 = p2i(p)
-        assert i2 == i
-        p2 = p2p(p)
-        assert ctypes.cast(p2, ctypes.c_void_p).value == ctypes.cast(p, ctypes.c_void_p).value
-        assert p2i(padd(p, 2)) == i + 2
-        assert p2i(pincr(p)) == i + 1
+        if T == V:
+            i = 79
+            p = i2p(i)
+            assert not isinstance(p, int), (type(p), p)
+            assert ctypes.cast(p, ctypes.c_void_p).value == i
+            i2 = p2i(p)
+            assert i2 == i
+            p2 = p2p(p)
+            assert ctypes.cast(p2, ctypes.c_void_p).value == ctypes.cast(p, ctypes.c_void_p).value
+            assert p2i(padd(p, 2)) == i + 2
+            assert p2i(pincr(p)) == i + 1
 
-    if 'void' in [T, V]:
-        i = 85
-        r = i2r(i)
-        assert not isinstance(r, int), (type(r), r)
+        if 'void' in [T, V]:
+            i = 85
+            r = i2r(i)
+            assert not isinstance(r, int), (type(r), r)
 
-        assert ctypes.cast(r, ctypes.c_void_p).value == i
-        p2 = r2p(r)
-        assert p2i(p2) == i
-        assert p2i(p2r(i2p(i))) == i
+            assert ctypes.cast(r, ctypes.c_void_p).value == i
+            p2 = r2p(r)
+            assert p2i(p2) == i
+            assert p2i(p2r(i2p(i))) == i
 
-    # double pointer-intp conversion
+        # double pointer-intp conversion
 
-    @rjit('T**(intp a)')
-    def i2pp(a):
-        return a
+        @rjit('T**(intp a)')
+        def i2pp(a):
+            return a
 
-    @rjit('V**(intp a)')
-    def i2rr(a):
-        return a
+        @rjit('V**(intp a)')
+        def i2rr(a):
+            return a
 
-    @rjit('intp(T** a)')
-    def pp2i(a):
-        return a
+        @rjit('intp(T** a)')
+        def pp2i(a):
+            return a
 
-    @rjit('intp(V** a)')
-    def rr2i(a):
-        return a
+        @rjit('intp(V** a)')
+        def rr2i(a):
+            return a
 
-    @rjit('T**(T** a)')
-    def pp2pp(a):
-        return a
+        @rjit('T**(T** a)')
+        def pp2pp(a):
+            return a
 
-    @rjit('T**(T** a, intp i)')
-    def ppadd(a, i):
-        return a + i
+        @rjit('T**(T** a, intp i)')
+        def ppadd(a, i):
+            return a + i
 
-    @rjit('T**(T** a)')
-    def ppincr(a):
-        return a + 1
+        @rjit('T**(T** a)')
+        def ppincr(a):
+            return a + 1
 
-    if T == V:
-        i = 89
-        pp = i2pp(i)
-        assert ctypes.cast(pp, ctypes.c_void_p).value == i
-        i2 = pp2i(pp)
-        assert i2 == i
-        pp2 = pp2pp(pp)
-        assert ctypes.cast(pp2, ctypes.c_void_p).value == ctypes.cast(pp, ctypes.c_void_p).value
-        assert pp2i(ppadd(pp, 2)) == i + 2
-        assert pp2i(ppincr(pp)) == i + 1
+        if T == V:
+            i = 89
+            pp = i2pp(i)
+            assert ctypes.cast(pp, ctypes.c_void_p).value == i
+            i2 = pp2i(pp)
+            assert i2 == i
+            pp2 = pp2pp(pp)
+            assert ctypes.cast(pp2, ctypes.c_void_p).value == ctypes.cast(
+                pp, ctypes.c_void_p).value
+            assert pp2i(ppadd(pp, 2)) == i + 2
+            assert pp2i(ppincr(pp)) == i + 1
 
-    # double pointer-pointer conversion
+        # double pointer-pointer conversion
 
-    @rjit('T**(T* a)')
-    def p2pp(a):
-        return a
+        @rjit('T**(T* a)')
+        def p2pp(a):
+            return a
 
-    @rjit('T*(T** a)')
-    def pp2p(a):
-        return a
+        @rjit('T*(T** a)')
+        def pp2p(a):
+            return a
 
-    # mixed pointer conversion requires void*
+        # mixed pointer conversion requires void*
 
-    @rjit('T**(V* a)')
-    def r2pp(a):
-        return a
+        @rjit('T**(V* a)')
+        def r2pp(a):
+            return a
 
-    @rjit('V*(T** a)')
-    def pp2r(a):
-        return a
+        @rjit('V*(T** a)')
+        def pp2r(a):
+            return a
 
-    if T == V:
-        i = 99
-        p = i2p(i)
-        pp = p2pp(p)
-        assert pp2i(pp) == i
-        assert p2i(pp2p(pp)) == i
+        if T == V:
+            i = 99
+            p = i2p(i)
+            pp = p2pp(p)
+            assert pp2i(pp) == i
+            assert p2i(pp2p(pp)) == i
 
-    if V == 'void':
-        i = 105
-        assert r2i(pp2r(i2pp(i))) == i
-        assert pp2i(r2pp(i2r(i))) == i
+        if V == 'void':
+            i = 105
+            assert r2i(pp2r(i2pp(i))) == i
+            assert pp2i(r2pp(i2r(i))) == i
 
 
 @pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
 def test_scalar_pointer_access_local(ljit, T):
-    Type.alias(T=T)
 
-    arr = np.array([1, 2, 3, 4], dtype=T)
-    arr2 = np.array([11, 12, 13, 14], dtype=T)
+    with Type.alias(T=T):
+        arr = np.array([1, 2, 3, 4], dtype=T)
+        arr2 = np.array([11, 12, 13, 14], dtype=T)
 
-    ptr = ctypes.c_void_p(arr.__array_interface__['data'][0])
+        ptr = ctypes.c_void_p(arr.__array_interface__['data'][0])
 
-    @ljit('T(T* x, int i)')
-    def pitem(x, i):
-        return x[i]
+        @ljit('T(T* x, int i)')
+        def pitem(x, i):
+            return x[i]
 
-    @ljit('void(T* x, int i, T)')
-    def sitem(x, i, v):
-        x[i] = v
+        @ljit('void(T* x, int i, T)')
+        def sitem(x, i, v):
+            x[i] = v
 
-    for i in range(len(arr)):
-        v = pitem(ptr, i)
-        assert v == arr[i]
+        for i in range(len(arr)):
+            v = pitem(ptr, i)
+            assert v == arr[i]
 
-    for i in range(len(arr)):
-        sitem(ptr, i, arr2[i])
+        for i in range(len(arr)):
+            sitem(ptr, i, arr2[i])
 
-    assert (arr == arr2).all()
+        assert (arr == arr2).all()
 
 
 memory_managers = dict(
@@ -504,41 +505,41 @@ memory_managers = dict(
 def test_scalar_pointer_access_remote(rjit, memman, T):
     calloc_prototype, free_prototype = memory_managers[memman]
 
-    Type.alias(T=T)
+    with Type.alias(T=T):
 
-    arr = np.array([1, 2, 3, 4], dtype=T)
-    arr2 = np.array([11, 12, 13, 14], dtype=T)
+        arr = np.array([1, 2, 3, 4], dtype=T)
+        arr2 = np.array([11, 12, 13, 14], dtype=T)
 
-    with TargetInfo.host():  # TODO: can we eliminate this?
-        calloc = external(calloc_prototype)
-        free = external(free_prototype)
+        with TargetInfo.host():  # TODO: can we eliminate this?
+            calloc = external(calloc_prototype)
+            free = external(free_prototype)
 
-    @rjit(calloc_prototype)
-    def rcalloc(nmemb, size):
-        return calloc(nmemb, size)
+        @rjit(calloc_prototype)
+        def rcalloc(nmemb, size):
+            return calloc(nmemb, size)
 
-    @rjit(free_prototype)
-    def rfree(ptr):
-        return free(ptr)
+        @rjit(free_prototype)
+        def rfree(ptr):
+            return free(ptr)
 
-    @rjit('T(T* x, int i)')
-    def pitem(x, i):
-        return x[i]
+        @rjit('T(T* x, int i)')
+        def pitem(x, i):
+            return x[i]
 
-    @rjit('void(T* x, int i, T)')
-    def sitem(x, i, v):
-        x[i] = v
+        @rjit('void(T* x, int i, T)')
+        def sitem(x, i, v):
+            x[i] = v
 
-    ptr = rcalloc(arr.itemsize, len(arr))
+        ptr = rcalloc(arr.itemsize, len(arr))
 
-    assert ptr.value
+        assert ptr.value
 
-    for i in range(len(arr)):
-        sitem(ptr, i, arr[i])
+        for i in range(len(arr)):
+            sitem(ptr, i, arr[i])
 
-    for i in range(len(arr2)):
-        arr2[i] = pitem(ptr, i)
+        for i in range(len(arr2)):
+            arr2[i] = pitem(ptr, i)
 
-    rfree(ptr)
+        rfree(ptr)
 
-    assert (arr == arr2).all()
+        assert (arr == arr2).all()

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -6,7 +6,6 @@ import numpy as np
 from rbc.remotejit import RemoteJIT, Signature, Caller
 from rbc.typesystem import Type
 from rbc.external import external
-from rbc.targetinfo import TargetInfo
 from rbc.irtools import sizeof
 
 win32 = sys.platform == 'win32'
@@ -511,9 +510,8 @@ def test_scalar_pointer_access_remote(rjit, memman, T):
         arr = np.array([1, 2, 3, 4], dtype=T)
         arr2 = np.array([11, 12, 13, 14], dtype=T)
 
-        with TargetInfo.host():  # TODO: can we eliminate this?
-            calloc = external(calloc_prototype)
-            free = external(free_prototype)
+        calloc = external(calloc_prototype)
+        free = external(free_prototype)
 
         @rjit(calloc_prototype)
         def rcalloc(nmemb, size):
@@ -605,8 +603,7 @@ def test_struct_input(ljit, rjit, location, T):
         # Set the members of struct given by reference
         # Manage memory of the arrays with struct values
 
-        with TargetInfo.host():  # TODO: can we eliminate this?
-            rcalloc, rfree = map(external, memory_managers['cstdlib'])
+        rcalloc, rfree = map(external, memory_managers['cstdlib'])
 
         @jit('S* allocate_S(size_t i)')
         def allocate_S(i):
@@ -708,8 +705,7 @@ def test_struct_pointer_members(ljit, rjit, location, T):
         nb_Sp = Type.fromstring(Sp).tonumba()
         nb_T = Type.fromstring(T).tonumba()
 
-        with TargetInfo.host():  # TODO: can we eliminate this?
-            rcalloc, rfree = map(external, memory_managers['cstdlib'])
+        rcalloc, rfree = map(external, memory_managers['cstdlib'])
 
         @jit('S* allocate_S(size_t i)')
         def allocate_S(i):
@@ -801,8 +797,7 @@ def test_struct_double_pointer_members(ljit, rjit, location, T):
         nb_Tp = Type.fromstring(Tp).tonumba()
         nb_Tpp = Type.fromstring(Tpp).tonumba()
 
-        with TargetInfo.host():  # TODO: can we eliminate this?
-            rcalloc, rfree = map(external, memory_managers['cstdlib'])
+        rcalloc, rfree = map(external, memory_managers['cstdlib'])
 
         @jit('S* allocate_S(size_t length, size_t size)')
         def allocate_S(length, size):

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -6,7 +6,7 @@ import numpy as np
 from rbc.remotejit import RemoteJIT, Signature, Caller
 from rbc.typesystem import Type
 from rbc.external import external
-from rbc.irtools import sizeof
+from rbc.externals.macros import sizeof, cast
 
 win32 = sys.platform == 'win32'
 
@@ -448,7 +448,7 @@ def test_scalar_pointer_conversion(rjit, T, V):
         def pp2r(a):
             return a
 
-        if T == V:
+        if T == V == 'void':
             i = 99
             p = i2p(i)
             pp = p2pp(p)
@@ -710,7 +710,7 @@ def test_struct_pointer_members(ljit, rjit, location, T):
         @jit('S* allocate_S(size_t i)')
         def allocate_S(i):
             raw = rcalloc(i, sizeof(nb_S))
-            s = raw.cast(nb_Sp)      # cast `void*` to `S*`
+            s = cast(raw, nb_Sp)     # cast `void*` to `S*`
             # s = raw.cast(Sp)       # cast `void*` to `S*`
             s.size = 0
             return s

--- a/rbc/tests/test_typesystem.py
+++ b/rbc/tests/test_typesystem.py
@@ -548,6 +548,30 @@ def test_mangling(target_info):
     check('()')
 
 
+def test_name_mangling(target_info):
+    def check(s):
+        t1 = Type.fromstring(s)
+        m = t1.mangle()
+        try:
+            t2 = Type.demangle(m)
+        except Exception:
+            print('subject: s=`%s`, t1=`%s`, m=`%s`' % (s, t1, m))
+            raise
+        assert t1 == t2, repr((t1, m, t2))
+        assert t1.name == t2.name, repr((t1, m, t2))
+
+    for t in ['int8', 'myint']:
+        check(f'{t} i')
+        check(f'{t} foo()')
+        check(f'foo({t} i)')
+        check(f'foo({t} i, float f)')
+        check(f'{t} ()')
+        check(f'{t}* i')
+        check(f'{{{t} i}}')
+        check(f'{{{t} i, float f}}')
+        check(f'{{{t} i, float f}} s')
+
+
 def test_unspecified(target_info):
     assert str(Type.fromstring('unknown(_0,_1)')) == 'unknown(_0, _1)'
 

--- a/rbc/tests/test_typesystem.py
+++ b/rbc/tests/test_typesystem.py
@@ -23,6 +23,10 @@ from rbc.utils import get_datamodel
 from rbc.targetinfo import TargetInfo
 
 
+if nb is not None:
+    from rbc.typesystem import boolean1, boolean8
+
+
 def test_dummy():
     with pytest.raises(
             RuntimeError,
@@ -245,6 +249,10 @@ def test_normalize(target_info):
     assert tostr('bool') == 'bool'
     assert tostr('b') == 'bool'
     assert tostr('_Bool') == 'bool'
+    assert tostr('bool1') == 'bool1'
+    assert tostr('boolean1') == 'bool1'
+    assert tostr('bool8') == 'bool8'
+    assert tostr('boolean8') == 'bool8'
 
     assert tostr('str') == 'string'
     assert tostr('string') == 'string'
@@ -359,7 +367,9 @@ def test_tonumba(target_info):
         return Type.fromstring(a).tonumba()
 
     assert tonumba('void') == nb.void
-    assert tonumba('bool') == nb.boolean
+    assert tonumba('bool') == boolean1
+    assert tonumba('bool1') == boolean1
+    assert tonumba('bool8') == boolean8
     assert tonumba('int8') == nb.int8
     assert tonumba('int16') == nb.int16
     assert tonumba('int32') == nb.int32

--- a/rbc/tests/test_utils.py
+++ b/rbc/tests/test_utils.py
@@ -1,4 +1,4 @@
-from rbc.utils import is_localhost, get_local_ip, triple_matches
+from rbc.utils import is_localhost, get_local_ip, triple_matches, check_returns_none
 
 
 def test_is_localhost():
@@ -11,3 +11,47 @@ def test_triple_matches():
     assert triple_matches('cuda32', 'nvptx-nvidia-cuda')
     assert triple_matches('nvptx-nvidia-cuda', 'cuda32')
     assert triple_matches('x86_64-pc-linux-gnu', 'x86_64-unknown-linux-gnu')
+
+
+def test_check_returns_none():
+
+    def foo():
+        return
+
+    assert check_returns_none(foo)
+
+    def foo():
+        return None
+
+    assert check_returns_none(foo)
+
+    def foo():
+        pass
+
+    assert check_returns_none(foo)
+
+    def foo():
+        if 1:
+            return
+        else:
+            return None
+
+    assert check_returns_none(foo)
+
+    def foo():
+        return 1
+
+    assert not check_returns_none(foo)
+
+    def foo():
+        if 1:
+            return
+        else:
+            return 1
+
+    assert not check_returns_none(foo)
+
+    def foo(a=None):
+        return a
+
+    assert not check_returns_none(foo)

--- a/rbc/tests/test_utils.py
+++ b/rbc/tests/test_utils.py
@@ -49,9 +49,34 @@ def test_check_returns_none():
         else:
             return 1
 
+    assert check_returns_none(foo)
+
+    def foo():
+        global a
+        if a:
+            return
+        else:
+            return 1
+
     assert not check_returns_none(foo)
 
     def foo(a=None):
         return a
 
     assert not check_returns_none(foo)
+
+    def foo(a):
+        if a:
+            return a + 1
+        else:
+            return
+    assert not check_returns_none(foo)
+
+    def foo(a):
+        pass
+    assert check_returns_none(foo)
+
+    def foo():
+        a = None
+        return a
+    assert not check_returns_none(foo)  # false-negative

--- a/rbc/thrift/dispatcher.py
+++ b/rbc/thrift/dispatcher.py
@@ -13,8 +13,9 @@ class Dispatcher(object):
     """Default implementation of a dispatcher.
     """
 
-    def __init__(self, server):
+    def __init__(self, server, debug=False):
         self.server = server
+        self.debug = debug
 
     @property
     def thrift(self):

--- a/rbc/thrift/server.py
+++ b/rbc/thrift/server.py
@@ -91,6 +91,7 @@ class Server(object):
         self.thrift_content_service = options.pop(
             'thrift_content_service', 'info')
         thrift_content = options.pop('thrift_content', None)
+        self.debug = options.pop('debug', False)
         self.options = options
         module_name = os.path.splitext(
             os.path.abspath(thrift_file))[0]+'_thrift'
@@ -153,11 +154,11 @@ class Server(object):
             s_proc = MultiplexedProcessor(self)
             for service_name in service_names:
                 service = getattr(self.thrift, service_name)
-                proc = thr.thrift.TProcessor(service, self._dispatcher(self))
+                proc = thr.thrift.TProcessor(service, self._dispatcher(self, debug=self.debug))
                 s_proc.register_processor(service_name, proc)
         else:
             service = getattr(self.thrift, self.thrift_content_service)
-            s_proc = Processor(self, service, self._dispatcher(self))
+            s_proc = Processor(self, service, self._dispatcher(self, debug=self.debug))
         server = thr.server.TThreadedServer(
             s_proc,
             thr.transport.TServerSocket(**self.options),

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -552,7 +552,8 @@ class Type(tuple, metaclass=MetaType):
 
     @property
     def is_aggregate(self):
-        return self.is_struct or self.is_function
+        # ref: https://llvm.org/docs/LangRef.html#aggregate-types
+        return self.is_struct
 
     @property
     def is_pointer(self):
@@ -1188,7 +1189,6 @@ class Type(tuple, metaclass=MetaType):
         if hasattr(obj, '__typesystem_type__'):
             return cls.fromobject(obj.__typesystem_type__)
 
-        # return cls.fromstring(type(obj).__name__)
         raise NotImplementedError('%s.fromvalue(%r|%s)'
                                   % (cls.__name__, obj, type(obj)))
 
@@ -1384,7 +1384,7 @@ class Type(tuple, metaclass=MetaType):
         if self.is_struct:
             return sum([m.bits for m in self])
         if self.is_pointer:
-            return 64  # TODO: check that pointer type bitwidth is 64
+            return TargetInfo().sizeof('void*') or 64
         return NotImplemented
 
     def match(self, other):
@@ -1492,7 +1492,6 @@ class Type(tuple, metaclass=MetaType):
                     return 1
                 return
             # TODO: lots of
-            # return None
             raise NotImplementedError(repr((self, other)))
         elif isinstance(other, tuple):
             if not self.is_function:

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -1384,7 +1384,7 @@ class Type(tuple, metaclass=MetaType):
         if self.is_struct:
             return sum([m.bits for m in self])
         if self.is_pointer:
-            return TargetInfo().sizeof('void*') or 64
+            return TargetInfo().sizeof('voidptr')*8 or 64
         return NotImplemented
 
     def match(self, other):

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -471,6 +471,8 @@ class Type(tuple, metaclass=MetaType):
         if isinstance(other, Type):
             self.annotation().update(other.annotation())
             for a, b in zip(self, other):
+                if b is None:
+                    continue
                 if isinstance(a, str):
                     pass
                 elif isinstance(a, Type):

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -913,7 +913,12 @@ class Type(tuple, metaclass=MetaType):
             typ = type(self).ctypes_types.get(ctypes_type_name)
             if typ is None:
                 rtype = self[0].toctypes()
-                atypes = [t.toctypes() for t in self[1] if not t.is_void]
+                atypes = []
+                for t in self[1]:
+                    if t.is_struct:
+                        atypes.extend([m.toctypes() for m in t])
+                    else:
+                        atypes.append(t.toctypes())
                 typ = ctypes.CFUNCTYPE(rtype, *atypes)
                 type(self).ctypes_types[ctypes_type_name] = typ
             return typ
@@ -1146,6 +1151,7 @@ class Type(tuple, metaclass=MetaType):
             return cls(cls(), '*')
         if hasattr(obj, '__typesystem_type__'):
             return cls.fromobject(obj.__typesystem_type__)
+
         # return cls.fromstring(type(obj).__name__)
         raise NotImplementedError('%s.fromvalue(%r|%s)'
                                   % (cls.__name__, obj, type(obj)))

--- a/rbc/utils.py
+++ b/rbc/utils.py
@@ -192,12 +192,13 @@ def check_returns_none(func):
     last_instr = None
     for instr in dis.Bytecode(func):
         if instr.opname == 'RETURN_VALUE':
-            if last_instr.opname in ['LOAD_CONST', 'LOAD_FAST']:
+            if last_instr.opname in ['LOAD_CONST', 'LOAD_FAST', 'LOAD_ATTR', 'LOAD_GLOBAL']:
                 if last_instr.argval is None:
                     continue
                 return False
             else:
-                if any(map(last_instr.opname.startswith, ['UNARY_', 'BINARY_', 'CALL_'])):
+                if any(map(last_instr.opname.startswith,
+                           ['UNARY_', 'BINARY_', 'CALL_', 'COMPARE_'])):
                     return False
                 warnings.warn(
                     f'check_returns_none: assuming non-None return from {last_instr=} (FIXME)')


### PR DESCRIPTION
As in title.

Related to #251 

### Note 1
This PR breaks BC regarding `Type.alias(...)`. Previous usage
```python
Type.alias(myint='int8')
```
must be replaced with
```python
with Type.alias(myint='int8'):
    assert Type.fromstring('myint') == Type.fromstring('int8')
assert Type.fromstring('myint') != Type.fromstring('int8')
```
The old behavior (register aliases globally) is possible via:
```python
Type.aliases.upate(myint='int8')
```