### PR TITLE
Add clang++ to conda environment 

### DIFF
--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -18,5 +18,6 @@ dependencies:
   - thriftpy2
   - netifaces
   - clang
+  - clangxx
   - six
   # - cudatoolkit-dev   # disable temporary


### PR DESCRIPTION
When running our CI tests in a clean conda container [0], the tests were failing due to `ctools` failing to find a c++17 compatible compiler on the system. Making sure clang++ is part of the resolved environment fixes this. 

0. https://github.com/omnisci/pyomnisci/blob/master/ci/test-rbc.sh