### PR TITLE
[on hold] Include omniscidb 5.6 on github CI

### DIFF
--- a/.github/workflows/rbc_test.yml
+++ b/.github/workflows/rbc_test.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.9, 3.8, 3.7]
-        omniscidb-version: [5.5, 5.4, 5.2]
+        omniscidb-version: [5.6, 5.5, 5.4, 5.2]
         omniscidb-from: [conda]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
On hold until https://github.com/conda-forge/omniscidb-feedstock/pull/40 gets merged