### PR TITLE
Update omniscidb versions in github actions, dropping 5.4 and 5.2.

### DIFF
--- a/.github/workflows/rbc_test.yml
+++ b/.github/workflows/rbc_test.yml
@@ -96,7 +96,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9, 3.8, 3.7]
         numba-version: [0.54, 0.53]
-        omniscidb-version: [5.5, 5.4, 5.2]
+        omniscidb-version: [5.7, 5.6, 5.5]
         omniscidb-from: [conda]
         include:
           - os: ubuntu-latest
@@ -113,8 +113,8 @@ jobs:
             omniscidb-from: docker
           - os: ubuntu-latest
             python-version: 3.8
-            omniscidb-version: 5.6.4
-            docker-image: omnisci/core-os-cpu:v5.6.4
+            omniscidb-version: 5.7.0
+            docker-image: omnisci/core-os-cpu:v5.7.0
             omniscidb-from: docker
 
     needs: lint

--- a/rbc/omnisci_backend/omnisci_column.py
+++ b/rbc/omnisci_backend/omnisci_column.py
@@ -24,7 +24,7 @@ class OmnisciColumnType(OmnisciBufferType):
     @property
     def pass_by_value(self):
         omnisci_version = TargetInfo().software[1][:3]
-        return omnisci_version < (5, 7, 0)
+        return omnisci_version <= (5, 7, 0)
 
 
 class OmnisciOutputColumnType(OmnisciColumnType):

--- a/rbc/tests/test_omnisci_column_runtime_alloc.py
+++ b/rbc/tests/test_omnisci_column_runtime_alloc.py
@@ -11,7 +11,7 @@ table_columns_map = dict(int64='i8', int32='i4', int16='i2', int8='i1',
 @pytest.fixture(scope='module')
 def omnisci():
 
-    for o in omnisci_fixture(globals(), minimal_version=(5, 7)):
+    for o in omnisci_fixture(globals(), minimal_version=(5, 7, 1)):
         define(o)
         yield o
 


### PR DESCRIPTION
As in the title.