### PR TITLE
Add a lock before updating the thrift config

### DIFF
--- a/rbc/thrift/client.py
+++ b/rbc/thrift/client.py
@@ -10,6 +10,7 @@ method `thrift_content`).
 import os
 import tempfile
 import warnings
+from threading import Lock
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import thriftpy2 as thr
@@ -17,6 +18,10 @@ with warnings.catch_warnings():
 import pickle
 import six
 from . import types
+
+
+# lock to prevent more than one thread from initializing the thrift client
+lock = Lock()
 
 
 def from_thrift(thrift, spec, result):
@@ -72,7 +77,8 @@ class Client(object):
         self.thrift_content_service = options.pop(
             'thrift_content_service', 'info')
         self.options = options
-        self._update_thrift()
+        with lock:
+            self._update_thrift()
 
     def _update_thrift(self):
         """Update client thrift configuration from server.


### PR DESCRIPTION
From slack chat, the following snippet of code reproduces the error:

```python
import ibis_omniscidb
import dask
from dask.distributed import Client
from dask import delayed
from multiprocessing import freeze_support
import os
import sys

def foo():

    dburl = "omniscidb://admin:HyperInteractive@localhost:6274/omnisci"

    n = 40 # int(sys.argv[1])

    client = Client(
        processes=True,
        threads_per_worker=20,
        n_workers=1)
# client = Client()

    def mytask(dburl):
        # con = ibis_omniscidb.connect(dburl)
        with ibis_omniscidb.OmniSciDBClient(uri=dburl) as con:
            return con.list_tables()[:1]

    def append(x, y):
        return x + y

    results = []
    for i in range(n):
        a = delayed(mytask)(dburl)
        results = delayed(append)(results, a)

    print(results.compute())

if __name__ == '__main__':
    freeze_support()
    foo()
```