### PR TITLE
Add support for table_function_error

### DIFF
--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -314,7 +314,6 @@ def compile_instance(func, sig,
         raise
 
     result = get_called_functions(cres.library, cres.fndesc.llvm_func_name)
-    #print(cres.library._final_module.get_function(cres.fndesc.llvm_func_name))
 
     for f in result['declarations']:
         if target.supports(f):

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -314,6 +314,7 @@ def compile_instance(func, sig,
         raise
 
     result = get_called_functions(cres.library, cres.fndesc.llvm_func_name)
+    #print(cres.library._final_module.get_function(cres.fndesc.llvm_func_name))
 
     for f in result['declarations']:
         if target.supports(f):

--- a/rbc/libfuncs.py
+++ b/rbc/libfuncs.py
@@ -51,7 +51,7 @@ class OmnisciDB(Library):
     name = 'omniscidb'
 
     _function_names = list('''
-    allocate_varlen_buffer set_output_row_size
+    allocate_varlen_buffer set_output_row_size table_function_error
     '''.strip().split())
 
 

--- a/rbc/tests/test_omnisci_udtf.py
+++ b/rbc/tests/test_omnisci_udtf.py
@@ -299,8 +299,7 @@ def test_table_function_error(omnisci):
     @omnisci('int32(Column<double>, double, RowMultiplier, OutputColumn<double>)')
     def my_divide(column, k, row_multiplier, out):
         if k == 0:
-            #return table_function_error('division by zero')
-            return table_function_error(1234)
+            return table_function_error('division by zero')
         for i in range(len(column)):
             out[i] = column[i] / k
         return len(column)

--- a/rbc/tests/test_omnisci_udtf.py
+++ b/rbc/tests/test_omnisci_udtf.py
@@ -1,5 +1,6 @@
 import pytest
 from rbc.tests import omnisci_fixture, sql_execute
+from rbc.externals.omniscidb import table_function_error
 import numpy as np
 
 
@@ -297,6 +298,9 @@ def test_table_function_error(omnisci):
 
     @omnisci('int32(Column<double>, double, RowMultiplier, OutputColumn<double>)')
     def my_divide(column, k, row_multiplier, out):
+        if k == 0:
+            #return table_function_error('division by zero')
+            return table_function_error(1234)
         for i in range(len(column)):
             out[i] = column[i] / k
         return len(column)

--- a/rbc/tests/test_omnisci_udtf.py
+++ b/rbc/tests/test_omnisci_udtf.py
@@ -294,6 +294,7 @@ def test_parallel_execution(omnisci, sleep, mode):
 
 
 def test_table_function_error(omnisci):
+    omnisci.require_version((5, 8), 'Requires omniscidb-internal PR 5879')
     omnisci.reset()
 
     @omnisci('int32(Column<double>, double, RowMultiplier, OutputColumn<double>)')


### PR DESCRIPTION
What the tittle says.

I **think** that `rbc` does not fully support string manipulations, because as soon as we use strings we quickly end up calling `PyUnicode_*` functions. To overcome the limitation, we require the message passed to `table_function_error` to be a string literal, similar to how numba implements `printf`.