### PR TITLE
Remove `label=` from some tests

### DIFF
--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -241,7 +241,7 @@ def test_binding(omnisci):
         column_vars_types = argument_types
 
     if available_version[:2] >= (5, 9):
-        omnisci.require_version((5, 9), 'Requires omniscidb-internal PR 6003', label='docker-dev')
+        omnisci.require_version((5, 9), 'Requires omniscidb-internal PR 6003')
 
         def get_result(overload_types, input_type, is_literal):
             overload_types_ = overload_types[::-1 if is_literal else 1]

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -547,16 +547,6 @@ omnisci_binary_operations = ['+', '-', '*', '/']
 @pytest.mark.parametrize("prop", ['', 'groupby'])
 @pytest.mark.parametrize("oper", omnisci_aggregators + omnisci_aggregators2)
 def test_column_aggregate(omnisci, prop, oper):
-    if not omnisci.has_cuda and oper in omnisci_aggregators2 and prop == 'groupby':
-        pytest.skip(f'{oper}-{prop} test crashes CPU-only omnisci server [rbc issue 237]')
-    if omnisci.has_cuda and oper in ['sample', 'stddev', 'stddev_pop', 'stddev_samp',
-                                     'correlation', 'corr']:
-        # unreliable means that the results computed on CPU and on
-        # CUDA device may slightly vary causing test failures.
-        pytest.skip(f'{oper}-{prop} test result unreliable when on CUDA')
-    if omnisci.has_cuda and oper in ['covar_samp', 'covar_pop']:
-        pytest.skip(f'{oper}-{prop} test crashes CUDA enabled omnisci server')
-
     omnisci.reset()
     omnisci.register()
 

--- a/rbc/tests/test_omnisci_template.py
+++ b/rbc/tests/test_omnisci_template.py
@@ -53,7 +53,7 @@ def test_template_text(omnisci, size):
 
     if omnisci.has_cuda:
         omnisci.require_version(
-            (5, 8), "Requires omniscidb-internal PR 5809", label='PR5809')
+            (5, 8), "Requires omniscidb-internal PR 5809")
 
     fn = "ct_binding_template"
     table = f"{omnisci.base_name}_{size}"
@@ -77,7 +77,7 @@ def test_template_number(omnisci, col):
 
     if omnisci.has_cuda:
         omnisci.require_version(
-            (5, 8), "Requires omniscidb-internal PR 5809", label='PR5809')
+            (5, 8), "Requires omniscidb-internal PR 5809")
 
     fn = "ct_binding_template"
     table = omnisci.table_name

--- a/rbc/tests/test_omnisci_udtf.py
+++ b/rbc/tests/test_omnisci_udtf.py
@@ -131,7 +131,7 @@ def test_composition(omnisci, kind):
 
 
 def test_table_function_manager(omnisci):
-    omnisci.require_version((5, 9), 'Requires omniscidb-internal PR 6035', label='master')
+    omnisci.require_version((5, 9), 'Requires omniscidb-internal PR 6035')
 
     @omnisci('int32(TableFunctionManager, Column<double>, OutputColumn<double>)')
     def my_manager_error(mgr, col, out):
@@ -169,8 +169,7 @@ def test_parallel_execution(omnisci, sleep, mode):
     (ct_sleep1).
 
     """
-    omnisci.require_version((5, 8), 'Requires omniscidb-internal PR 5901',
-                            label='qe-99')
+    omnisci.require_version((5, 8), 'Requires omniscidb-internal PR 5901')
     from multiprocessing import Process, Array
 
     def func(seconds, mode, a):


### PR DESCRIPTION
This PR removes the `label=...` of a few tests that were not being executed in a pytest run. I've tested it on 
* omniscidb 5.7 cpu/gpu
* omniscidb 5.8 cpu/gpu
* omniscidb 5.9 cpu/gpu
* omniscidb master cpu/gpu