### PR TITLE
Change the return value if the array is empty for `max`

### DIFF
--- a/rbc/omnisci_backend/numpy_funcs.py
+++ b/rbc/omnisci_backend/numpy_funcs.py
@@ -279,7 +279,7 @@ def omnisci_np_prod(a, initial=None):
 @expose_and_overload(np.mean)
 @extending.overload_method(ArrayPointer, 'mean')
 def omnisci_array_mean(x):
-    zero_value = np.nan  # 0 if x.dtype is int
+    zero_value = np.nan
 
     if isinstance(x, ArrayPointer):
         def impl(x):

--- a/rbc/omnisci_backend/numpy_funcs.py
+++ b/rbc/omnisci_backend/numpy_funcs.py
@@ -200,7 +200,8 @@ def omnisci_array_max(x, initial=None):
         def impl(x, initial=None):
             if len(x) <= 0:
                 printf("omnisci_array_max: cannot find max of zero-sized array")  # noqa: E501
-                return min_value
+                # the array api standard says this is implementation specific
+                return min_value + 1
             if initial is not None:
                 m = initial
             else:

--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -9,6 +9,9 @@ available_version, reason = rbc_omnisci.is_available()
 pytestmark = pytest.mark.skipif(not available_version, reason=reason)
 
 
+NUMERIC_TYPES = ['int8', 'int16', 'int32', 'int64', 'float32', 'float64']
+
+
 @pytest.fixture(scope='module')
 def omnisci():
     for o in omnisci_fixture(globals()):
@@ -19,13 +22,27 @@ def omnisci():
 ndarray_methods = [
     ('fill', (5, 4), [4.0, 4.0, 4.0, 4.0, 4.0]),
     ('max', (5, 4.0), 4.0),
-    ('max_empty', (0, ), -127),
+    ('max_empty_int8', (0, ), np.iinfo(np.int8).min + 1),
+    ('max_empty_int16', (0, ), np.iinfo(np.int16).min + 1),
+    ('max_empty_int32', (0, ), np.iinfo(np.int32).min + 1),
+    ('max_empty_int64', (0, ), np.iinfo(np.int64).min + 1),
+    ('max_empty_float32', (0, ), np.finfo(np.float32).min),
+    ('max_empty_float64', (0, ), np.finfo(np.float64).min),
     ('max_initial', (5, 4.0, 30.0), 30.0),
     ('mean', (5, 2.0), 2.0),
-    ('mean_empty_float', (0, ), np.nan),
-    ('mean_empty_int', (0, ), 0),
+    ('mean_empty_int8', (0, ), 0),
+    ('mean_empty_int16', (0, ), 0),
+    ('mean_empty_int32', (0, ), 0),
+    ('mean_empty_int64', (0, ), 0),
+    ('mean_empty_float32', (0, ), np.nan),
+    ('mean_empty_float64', (0, ), np.nan),
     ('min', (5, 4.0), 4.0),
-    ('min_empty', (0, ), 32767),
+    ('min_empty_int8', (0, ), np.iinfo(np.int8).max),
+    ('min_empty_int16', (0, ), np.iinfo(np.int16).max),
+    ('min_empty_int32', (0, ), np.iinfo(np.int32).max),
+    ('min_empty_int64', (0, ), np.iinfo(np.int64).max),
+    ('min_empty_float32', (0, ), np.finfo(np.float32).max),
+    ('min_empty_float64', (0, ), np.finfo(np.float64).max),
     ('min_initial', (5, 4.0, -3.0), -3.0),
     ('sum', (5, 2.0), 10.0),
     ('sum_initial', (5, 2.0, 2.0), 12.0),
@@ -48,10 +65,15 @@ def define(omnisci):
         a.fill(v)
         return a.max()
 
-    @omnisci('int8(int32)')
-    def ndarray_max_empty(size):
-        a = Array(size, 'int8')
-        return a.max()
+    for retty in NUMERIC_TYPES:
+        for op in ('min', 'max', 'mean'):
+            fn_name = f'ndarray_{op}_empty_{retty}'
+            fn = (f'def {fn_name}(size):\n'
+                  f'    a = Array(size, "{retty}")\n'
+                  f'    return a.{op}()\n')
+            exec(fn)
+            fn = locals()[fn_name]
+            omnisci(f'{retty}(int32)')(fn)
 
     @omnisci('double(int64, double, double)')
     def ndarray_max_initial(size, v, initial):
@@ -65,25 +87,10 @@ def define(omnisci):
         a.fill(v)
         return a.mean()
 
-    @omnisci('float64(int64)')
-    def ndarray_mean_empty_float(size):
-        a = Array(size, 'float64')
-        return a.mean()
-
-    @omnisci('float64(int64)')
-    def ndarray_mean_empty_int(size):
-        a = Array(size, 'int32')
-        return a.mean()
-
     @omnisci('double(int64, double)')
     def ndarray_min(size, v):
         a = Array(size, 'double')
         a.fill(v)
-        return a.min()
-
-    @omnisci('int16(int64)')
-    def ndarray_min_empty(size):
-        a = Array(size, 'int16')
         return a.min()
 
     @omnisci('double(int64, double, double)')

--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -19,7 +19,7 @@ def omnisci():
 ndarray_methods = [
     ('fill', (5, 4), [4.0, 4.0, 4.0, 4.0, 4.0]),
     ('max', (5, 4.0), 4.0),
-    ('max_empty', (0, ), -128),
+    ('max_empty', (0, ), -127),
     ('max_initial', (5, 4.0, 30.0), 30.0),
     ('mean', (5, 2.0), 2.0),
     ('mean_empty_float', (0, ), np.nan),
@@ -120,11 +120,6 @@ def define(omnisci):
 @pytest.mark.parametrize("method, args, expected", ndarray_methods,
                          ids=[item[0] for item in ndarray_methods])
 def test_ndarray_methods(omnisci, method, args, expected):
-    if method in ['max_empty']:
-        pytest.skip(
-            f'{method}: fails on CPU-only omniscidb server'
-            ' v 5.3.1+ [issue 114]')
-
     query_args = ', '.join(map(str, args))
     query = f'SELECT ndarray_{method}({query_args})'
 

--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -30,6 +30,7 @@ ndarray_methods = [
     ('max_empty_float64', (0, ), np.finfo(np.float64).min),
     ('max_initial', (5, 4.0, 30.0), 30.0),
     ('mean', (5, 2), 2.0),
+    ('mean', (5, 2.0), 2.0),
     ('mean_empty_int8', (0, ), np.nan),
     ('mean_empty_int16', (0, ), np.nan),
     ('mean_empty_int32', (0, ), np.nan),

--- a/rbc/tests/test_omnisci_array_methods.py
+++ b/rbc/tests/test_omnisci_array_methods.py
@@ -29,11 +29,11 @@ ndarray_methods = [
     ('max_empty_float32', (0, ), np.finfo(np.float32).min),
     ('max_empty_float64', (0, ), np.finfo(np.float64).min),
     ('max_initial', (5, 4.0, 30.0), 30.0),
-    ('mean', (5, 2.0), 2.0),
-    ('mean_empty_int8', (0, ), 0),
-    ('mean_empty_int16', (0, ), 0),
-    ('mean_empty_int32', (0, ), 0),
-    ('mean_empty_int64', (0, ), 0),
+    ('mean', (5, 2), 2.0),
+    ('mean_empty_int8', (0, ), np.nan),
+    ('mean_empty_int16', (0, ), np.nan),
+    ('mean_empty_int32', (0, ), np.nan),
+    ('mean_empty_int64', (0, ), np.nan),
     ('mean_empty_float32', (0, ), np.nan),
     ('mean_empty_float64', (0, ), np.nan),
     ('min', (5, 4.0), 4.0),
@@ -73,7 +73,10 @@ def define(omnisci):
                   f'    return a.{op}()\n')
             exec(fn)
             fn = locals()[fn_name]
-            omnisci(f'{retty}(int32)')(fn)
+            if op == 'mean':
+                omnisci('float64(int32)')(fn)
+            else:
+                omnisci(f'{retty}(int32)')(fn)
 
     @omnisci('double(int64, double, double)')
     def ndarray_max_initial(size, v, initial):


### PR DESCRIPTION
The [array API](https://data-apis.org/array-api/latest/API_specification/statistical_functions.html#max-x-axis-none-keepdims-false) says the maximum value when the container is empty is implementation specific. In RBC case, we choose to return the minimum value for the container type, but this collides with the value omniscidb uses to signal a null value.

For reference, below is the set of values omniscidb uses as a sentinel for null values.
```javascript
{
    'boolean8': -128,
    'int8': -128,
    'int16': -32768,
    'int32': -2147483648,
    'int64': -9223372036854775808,
    'uint8': 255,
    'uint16': 65535,
    'uint32': 4294967295,
    'uint64': 18446744073709551615,
    'float32': 1.1754944e-38,
    'float64': 2.2250738585072014e-308,
    'Array<boolean8>': -127,
    'Array<int8>': -127,
    'Array<int16>': -32767,
    'Array<int32>': -2147483647,
    'Array<int64>': -9223372036854775807,
    'Array<float32>': 2.3509887e-38,
    'Array<float64>': 4.450147717014403e-308
}
```

I'm open for suggestions for other values to use as sentinel

Fixes #114 