### PR TITLE
Fix memory leaks when allocating buffers and arrays

### DIFF
--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -258,9 +258,8 @@ def free_buffer(typingctx, buf):
         free_buffer_fn = irutils.get_or_insert_function(
             builder.module, free_buffer_fnty, free_buffer_fn_name)
 
-        # free all the buffers apart value_to_keep_alive
         [buf] = args
-        buf_ptr = builder.load(builder.gep(buf, [int32_t(0), int32_t(0)])) # buf.ptr
+        buf_ptr = builder.load(builder.gep(buf, [int32_t(0), int32_t(0)]))  # buf.ptr
         buf_ptr = builder.bitcast(buf_ptr, int8_t.as_pointer())
         builder.call(free_buffer_fn, [buf_ptr])
 
@@ -583,6 +582,7 @@ def omnisci_buffer_set_null(x, row_idx=None):
                 return omnisci_buffer_idx_set_null(x, row_idx)
             return impl
         return impl
+
 
 @extending.overload_method(BufferPointer, 'free')
 def omnisci_buffer_free(x):

--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -194,8 +194,20 @@ def omnisci_buffer_constructor(context, builder, sig, args):
 
 
 @extending.intrinsic
-def free_omnisci_buffer(typingctx, ret):
-    sig = types.void(ret)
+def free_all_other_buffers(typingctx, value_to_keep_alive):
+    """
+    Black magic function which automatically frees all the buffers which were
+    allocated in the function apart the given one.
+
+    value_to_keep_alive can be of any type:
+      - if it's of a Buffer type, it will be kept alive and not freed
+      - if it's of any other type, all buffers will be freed unconditionally
+
+    The end user should never call this function explicitly: it is
+    automatically inserted by omnisci_pipeline.AutoFreeBuffers.
+    """
+
+    sig = types.void(value_to_keep_alive)
 
     def codegen(context, builder, signature, args):
         buffers = builder_buffers[builder]
@@ -211,16 +223,16 @@ def free_omnisci_buffer(typingctx, ret):
         free_buffer_fn = irutils.get_or_insert_function(
             builder.module, free_buffer_fnty, free_buffer_fn_name)
 
-        # We skip the ret pointer iff we're returning a Buffer
-        # otherwise, we free everything
-        if isinstance(ret, BufferPointer):
-            [arg] = args
-            ptr = builder.load(builder.gep(arg, [int32_t(0), int32_t(0)]))
-            ptr = builder.bitcast(ptr, int8_t.as_pointer())
+        if isinstance(value_to_keep_alive, BufferPointer):
+            # free all the buffers apart value_to_keep_alive
+            [keep_alive] = args
+            keep_alive_ptr = builder.load(builder.gep(keep_alive, [int32_t(0), int32_t(0)]))
+            keep_alive_ptr = builder.bitcast(keep_alive_ptr, int8_t.as_pointer())
             for ptr8 in buffers:
-                with builder.if_then(builder.icmp_signed('!=', ptr, ptr8)):
+                with builder.if_then(builder.icmp_signed('!=', keep_alive_ptr, ptr8)):
                     builder.call(free_buffer_fn, [ptr8])
         else:
+            # free all the buffers unconditionally
             for ptr8 in buffers:
                 builder.call(free_buffer_fn, [ptr8])
 

--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -583,3 +583,10 @@ def omnisci_buffer_set_null(x, row_idx=None):
                 return omnisci_buffer_idx_set_null(x, row_idx)
             return impl
         return impl
+
+@extending.overload_method(BufferPointer, 'free')
+def omnisci_buffer_free(x):
+    if isinstance(x, BufferPointer):
+        def impl(x):
+            return free_buffer(x)
+        return impl

--- a/rbc/rbclib/_rbclib.c
+++ b/rbc/rbclib/_rbclib.c
@@ -20,9 +20,5 @@ RBC_DLLEXPORT int8_t *rbclib_allocate_varlen_buffer(int64_t element_count, int64
 }
 
 RBC_DLLEXPORT void rbclib_free_buffer(int8_t *addr) {
-    // XXX: currently there is a bug in the FreeOmnisciBuffer and the free()
-    // is never called.  We should remove the abort() as soon as this code is
-    // actually called
-    abort();
     free((void*)addr);
 }

--- a/rbc/tests/stdlib/test_array_api.py
+++ b/rbc/tests/stdlib/test_array_api.py
@@ -17,6 +17,18 @@ def test_array_free_function_call(djit):    # noqa: F811
     assert res == 10
 
 
+def test_array_free_method(djit):    # noqa: F811
+
+    @djit('int32(int32)')
+    def fn(size):
+        a = xp.Array(size, xp.float64)
+        a.free()
+        return size
+
+    res = fn(10)
+    assert res == 10
+
+
 @pytest.mark.xfail(raises=MemoryLeakError, reason='issue #377')
 def test_array_constructor_noreturn(djit):    # noqa: F811
 

--- a/rbc/tests/stdlib/test_array_api.py
+++ b/rbc/tests/stdlib/test_array_api.py
@@ -1,7 +1,20 @@
 import pytest
 from rbc.stdlib import array_api as xp
 from rbc.rbclib.tracing_allocator import MemoryLeakError
+from rbc.omnisci_backend.omnisci_buffer import free_buffer
 from ..test_rbclib import djit  # noqa: F401
+
+
+def test_array_free_function_call(djit):    # noqa: F811
+
+    @djit('int32(int32)')
+    def fn(size):
+        a = xp.Array(size, xp.float64)
+        free_buffer(a)
+        return size
+
+    res = fn(10)
+    assert res == 10
 
 
 @pytest.mark.xfail(raises=MemoryLeakError, reason='issue #377')

--- a/rbc/tests/stdlib/test_array_api.py
+++ b/rbc/tests/stdlib/test_array_api.py
@@ -29,7 +29,6 @@ def test_array_free_method(djit):    # noqa: F811
     assert res == 10
 
 
-@pytest.mark.xfail(raises=MemoryLeakError, reason='issue #377')
 def test_array_constructor_noreturn(djit):    # noqa: F811
 
     @djit('float64(int32)')
@@ -42,6 +41,9 @@ def test_array_constructor_noreturn(djit):    # noqa: F811
         s = 0.0
         for i in range(size):
             s += a[i] + b[i] + c[i] - a[i] * b[i]
+        a.free()
+        b.free()
+        c.free()
         return s
 
     res = array_noreturn(10)

--- a/rbc/tests/stdlib/test_array_api.py
+++ b/rbc/tests/stdlib/test_array_api.py
@@ -1,6 +1,4 @@
-import pytest
 from rbc.stdlib import array_api as xp
-from rbc.rbclib.tracing_allocator import MemoryLeakError
 from rbc.omnisci_backend.omnisci_buffer import free_buffer
 from ..test_rbclib import djit  # noqa: F401
 


### PR DESCRIPTION
I think this is ready for review, assuming all tests ill be green.
The core of this PR is to introduce the method `BufferPointer.free()`, which you can use to manually free the memory allocated by arrays and avoid the memory leak described in #377 .

Summary of changes:
- introduce `BufferPointer.free()` and finally remove the `@xfail` from `test_array_constructor_noreturn`.
- rename `free_omnisci_buffer` into `free_all_other_buffers` and add a docstring: the original name was very confusing IMHO, and moreover nowadays it's no longer omnisci-specific
- similarly, rename the llvm pass `FreeOmnisciBuffer` into `AutoFreeBuffers` and add a docstring to explain how it works (although it's probably broken)

Once this is merged, I plan to do a follow-up PR to finally fix `AutoFreeBuffers` and/or kill it if we decide that it is ultimately unfixable.

**EDIT**: I spoke too fast and the build is failing. Failures look unrelated but I'm going to investigate

**EDIT 2**: I re-ran the workflow and the build is all green now. It looks like we have flaky tests, which is a problem on its own but not for this PR :). @pearu @guilhermeleobas @brenocfg I think it's ready to review for real now