### PR TITLE
Better error messages when cffi is missing

### DIFF
--- a/rbc/rbclib/__init__.py
+++ b/rbc/rbclib/__init__.py
@@ -44,7 +44,7 @@ try:
     from . import _rbclib
 except ImportError as e:
     # improve the ImportError error message
-    msg = ("cannot import rbc.rbclib._rbclib: this probably indicates "
+    msg = (f"{e}\nThis probably indicates "
            "that rbc has not been built/installed correctly, possibly "
            "because cffi was not available at compilation time")
     e.msg = msg

--- a/rbc/rbclib/__init__.py
+++ b/rbc/rbclib/__init__.py
@@ -40,7 +40,17 @@ functions. However, using CFFI has many advantages:
 """
 
 import llvmlite.binding
-from . import _rbclib
+try:
+    from . import _rbclib
+except ImportError as e:
+    # improve the ImportError error message
+    msg = ("cannot import rbc.rbclib._rbclib: this probably indicates "
+           "that rbc has not been built/installed correctly, possibly "
+           "because cffi was not available at compilation time")
+    e.msg = msg
+    e.args = (msg,)
+    raise
+
 from ._rbclib import lib, ffi  # noqa: F401
 from .intrinsic import add_ints  # noqa: F401
 from . import tracing_allocator  # noqa: F401, side effects

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ def setup_package():
         # ignored and result in an ImportError at runtime
         try:
             import cffi  # noqa: F401
-        except ImportError:
-            msg = ('Cannot find cffi, which is a required build-time dependency. '
-                   'Please do:\n'
-                   '              conda install -c conda-forge cffi')
+        except ImportError as e:
+            msg = (f'{e}\n'
+                   f'cffi is a required build-time dependency, please do:\n'
+                   f'    conda install -c conda-forge cffi')
             raise RuntimeError(msg)
     else:
         # Get requirements via PyPI. Use at your own risk as more than

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import builtins
 import versioneer
 
 if sys.version_info[:2] < (3, 7):
@@ -41,7 +40,7 @@ def setup_package():
         # manually check that cffi is available, else _rbclib is silently
         # ignored and result in an ImportError at runtime
         try:
-            import cffi
+            import cffi  # noqa: F401
         except ImportError:
             msg = ('Cannot find cffi, which is a required build-time dependency. '
                    'Please do:\n'

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,15 @@ def setup_package():
         install_requires = []
         setup_requires = []
         tests_require = []
+        # manually check that cffi is available, else _rbclib is silently
+        # ignored and result in an ImportError at runtime
+        try:
+            import cffi
+        except ImportError:
+            msg = ('Cannot find cffi, which is a required build-time dependency. '
+                   'Please do:\n'
+                   '              conda install -c conda-forge cffi')
+            raise RuntimeError(msg)
     else:
         # Get requirements via PyPI. Use at your own risk as more than
         # once the numba and llvmlite have not matched.

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ import versioneer
 if sys.version_info[:2] < (3, 7):
     raise RuntimeError("Python version >= 3.7 required.")
 
-builtins.__RBC_SETUP__ = True
-
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 
@@ -96,4 +94,3 @@ def setup_package():
 
 if __name__ == '__main__':
     setup_package()
-    del builtins.__RBC_SETUP__


### PR DESCRIPTION
This PR does three things:
- make cffi a hard build-time dependency even if we are in a conda env, and exit clearly if it's missing: fixes #396 
- improve the error message that you get if `_rbclib` was not built. This should no longer be possible thanks to the point above, but better safe than sorry. Fixed #397 
- remove the weird `builtins.__RBC_SETUP__` hack which seems to be unused; I couldn't find any reference to it in the whole git history, so it's probably a very very old remaining; @pearu do you remember what was it?
