### PR TITLE
ENH: forbid direct calls to `RemoteOmnisci`

### DIFF
--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -278,42 +278,11 @@ class RemoteOmnisci(RemoteJIT):
         self.has_cuda = None
         self._null_values = dict()
 
+        # Registered functions can only be called from a SQL query
+        self._supports_callable_caller = False
+
         # An user-defined device-LLVM IR mapping.
         self.user_defined_llvm_ir = {}
-
-    def __call__(self, *args, **kwargs):
-        msg = """Cannot call functions decorated by `RemoteOmnisci`.
-        These functions are registered on the database and can be called only
-        from a SQL query.
-
-        Following is a proper usage of `RemoteOmnisci`.
-
-        >>> from rbc.omniscidb import RemoteOmnisci
-        >>> omni = RemoteOmnisci()
-        >>> @omni('double(double)')
-        ... def farenheight2celcius(f):
-        ...     return (f - 32) * 5 / 9
-        ...
-        >>> _, r = omni.sql_execute('select farenheight2celcius(40)')
-        >>> print(list(r))
-        [(4.444444444444445,)]
-
-        Alternatively, you can define a Python function and decorate it
-        in a second step. This allows you to be able to call the Python
-        function. In any case, the decorated function cannot be called.
-
-        >>> omni = RemoteOmnisci()
-        >>> def farenheight2celcius(f):
-        ...     return (f - 32) * 5 / 9
-        ...
-        >>> decorated = omni('double(double)')(farenheight2celcius)
-        >>> _, r=omni.sql_execute('select farenheight2celcius(40)')
-        >>> print(list(r))
-        [(4.444444444444445,)]
-        >>> print(farenheight2celcius(40))
-        4.444444444444445
-        """
-        raise UnsupportedError(msg)
 
     def _init_thrift_typemap(self):
         """Initialize thrift type map using client thrift configuration.

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -282,9 +282,9 @@ class RemoteOmnisci(RemoteJIT):
         self.user_defined_llvm_ir = {}
 
     def __call__(self, *args, **kwargs):
-        msg = """Decorated functions called directly. Decorated function are
-        not meant to be called directly, but are registered and later
-        executed directly on the database.
+        msg = """Cannot call functions decorated by `RemoteOmnisci`.
+        These functions are registered on the database and can be called only
+        from a SQL query.
 
         Following is a proper usage of `RemoteOmnisci`.
 

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -18,7 +18,7 @@ from .omnisci_backend import (
     BufferMeta, OmnisciColumnListType, OmnisciTableFunctionManagerType)
 from .targetinfo import TargetInfo
 from .irtools import compile_to_LLVM
-from .errors import ForbiddenNameError, OmnisciServerError, UnsupportedError
+from .errors import ForbiddenNameError, OmnisciServerError
 from .utils import parse_version
 from . import ctools
 from . import typesystem

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -294,7 +294,7 @@ class RemoteOmnisci(RemoteJIT):
         ... def farenheight2celcius(f):
         ...     return (f - 32) * 5 / 9
         ...
-        >>> _, r=omni.sql_execute('select farenheight2celcius(40)')
+        >>> _, r = omni.sql_execute('select farenheight2celcius(40)')
         >>> print(list(r))
         [(4.444444444444445,)]
 
@@ -306,7 +306,7 @@ class RemoteOmnisci(RemoteJIT):
         >>> def farenheight2celcius(f):
         ...     return (f - 32) * 5 / 9
         ...
-        >>> omni('double(double)')(farenheight2celcius)
+        >>> decorated = omni('double(double)')(farenheight2celcius)
         >>> _, r=omni.sql_execute('select farenheight2celcius(40)')
         >>> print(list(r))
         [(4.444444444444445,)]

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -362,9 +362,7 @@ class Caller(object):
         if not self.remotejit._supports_callable_caller:
             msg = (
                 "Cannot call functions decorated by "
-                f"{self.remotejit.__class__}. These functions are "
-                "registered on the database and can be called "
-                "only from a SQL query."
+                f"{type(self.remotejit)}."
             )
             raise UnsupportedError(msg)
 

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -317,6 +317,13 @@ class Caller(object):
         """Return Caller instance that executes function calls on the local
         host. Useful for debugging.
         """
+        if not self.remotejit._supports_callable_caller:
+            msg = (
+                "Cannot create a local `Caller` when using "
+                f"{type(self.remotejit)}."
+            )
+            raise UnsupportedError(msg)
+
         return Caller(self.func, self.signature.local)
 
     def __repr__(self):

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -320,7 +320,7 @@ class Caller(object):
         if not self.remotejit._supports_callable_caller:
             msg = (
                 "Cannot create a local `Caller` when using "
-                f"{type(self.remotejit)}."
+                f"{type(self.remotejit).__name__}."
             )
             raise UnsupportedError(msg)
 
@@ -369,7 +369,7 @@ class Caller(object):
         if not self.remotejit._supports_callable_caller:
             msg = (
                 "Cannot call functions decorated by "
-                f"{type(self.remotejit)}."
+                f"{type(self.remotejit).__name__}."
             )
             raise UnsupportedError(msg)
 

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -72,7 +72,7 @@ def test_direct_call(omnisci):
     def farenheight2celcius(f):
         return (f - 32) * 5 / 9
 
-    msg = "Decorated functions called directly"
+    msg = "Cannot call functions"
     with pytest.raises(UnsupportedError, match=msg):
         farenheight2celcius(40)
 

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -85,7 +85,7 @@ def test_local_caller(omnisci):
 
     caller = omnisci('double(double)')(func)
 
-    msg = "Cannot call functions"
+    msg = "Cannot create a local `Caller`"
     with pytest.raises(UnsupportedError, match=msg):
         _ = caller.local
 

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -77,6 +77,19 @@ def test_direct_call(omnisci):
         farenheight2celcius(40)
 
 
+def test_local_caller(omnisci):
+    omnisci.reset()
+
+    def func(f):
+        return f
+
+    caller = omnisci('double(double)')(func)
+
+    msg = "Cannot call functions"
+    with pytest.raises(UnsupportedError, match=msg):
+        _ = caller.local
+
+
 def test_redefine(omnisci):
     omnisci.reset()
 

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -1,6 +1,8 @@
 import os
 import itertools
 import pytest
+
+from rbc.errors import UnsupportedError
 from rbc.tests import omnisci_fixture
 
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
@@ -61,6 +63,18 @@ def nb_version():
 def omnisci():
     for o in omnisci_fixture(globals()):
         yield o
+
+
+def test_direct_call(omnisci):
+    omnisci.reset()
+
+    @omnisci('double(double)')
+    def farenheight2celcius(f):
+        return (f - 32) * 5 / 9
+
+    msg = "Decorated functions called directly"
+    with pytest.raises(UnsupportedError, match=msg):
+        farenheight2celcius(40)
 
 
 def test_redefine(omnisci):


### PR DESCRIPTION
Closes #400

Add `__call__` to `RemoteOmnisci` which raises with clear documentation on how to properly use it.