### PR TITLE
Implement dtype attribute access and comparison

### DIFF
--- a/rbc/omnisci_backend/omnisci_buffer.py
+++ b/rbc/omnisci_backend/omnisci_buffer.py
@@ -590,3 +590,23 @@ def omnisci_buffer_free(x):
         def impl(x):
             return free_buffer(x)
         return impl
+
+
+@extending.overload(operator.eq)
+def dtype_eq(a, b):
+    if isinstance(a, types.DTypeSpec) and isinstance(b, types.DTypeSpec):
+        eq = (a == b)
+
+        def impl(a, b):
+            return eq
+        return impl
+
+
+@extending.overload_attribute(BufferPointer, 'dtype')
+def omnisci_buffer_dtype(x):
+    if isinstance(x, BufferPointer):
+        dtype = x.eltype
+
+        def impl(x):
+            return dtype
+        return impl

--- a/rbc/tests/test_omnisci_array.py
+++ b/rbc/tests/test_omnisci_array.py
@@ -471,3 +471,18 @@ def test_issue77(omnisci):
             _, result = omnisci.sql_execute('select issue77();')
 
         assert exc.match('Could not bind issue77()')
+
+
+def test_array_dtype(omnisci):
+    table = omnisci.table_name
+
+    @omnisci('T(T[])', T=['int32', 'int64'])
+    def array_dtype_fn(x):
+        if x.dtype == nb_types.int32:
+            return 32
+        else:
+            return 64
+
+    for col, r in (('i4', 32), ('i8', 64)):
+        _, result = omnisci.sql_execute(f'select array_dtype_fn({col}) from {table}')
+        assert list(result) == [(r,)] * 5

--- a/rbc/tests/test_omnisci_array_functions.py
+++ b/rbc/tests/test_omnisci_array_functions.py
@@ -140,3 +140,17 @@ def test_array_methods(omnisci, method, signature, args, expected):
     out = list(result)[0]
 
     assert np.array_equal(expected, out[0]), 'np_' + method
+
+
+@pytest.mark.parametrize('col', ('i4', 'i8', 'f4'))
+def test_dtype(omnisci, col):
+    omnisci.reset()
+
+    @omnisci('T[](T[])', T=['int32', 'int64', 'float32'], devices=['cpu'])
+    def zeros_like(x):
+        z = omni.zeros(len(x), x.dtype)
+        return z
+
+    query = f'select zeros_like({col}) from {omnisci.table_name} limit 1;'
+    _, result = omnisci.sql_execute(query)
+    assert np.all(list(result)[0][0] == np.zeros(6, dtype=col))

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -550,7 +550,7 @@ def test_column_aggregate(omnisci, prop, oper):
     omnisci.reset()
     omnisci.register()
 
-    if prop == 'groupby' and oper == 'corr':
+    if prop == 'groupby':
         pytest.skip('omniscidb server crashes')
 
     if oper == 'single_value':

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -550,6 +550,10 @@ def test_column_aggregate(omnisci, prop, oper):
     omnisci.reset()
     omnisci.register()
 
+
+    if prop == 'groupby' and oper == 'corr':
+        pytest.skip('omniscidb server crashes')
+
     if oper == 'single_value':
         if prop:
             return

--- a/rbc/tests/test_omnisci_column_basic.py
+++ b/rbc/tests/test_omnisci_column_basic.py
@@ -550,7 +550,6 @@ def test_column_aggregate(omnisci, prop, oper):
     omnisci.reset()
     omnisci.register()
 
-
     if prop == 'groupby' and oper == 'corr':
         pytest.skip('omniscidb server crashes')
 


### PR DESCRIPTION
As title. This PR implements access to `dtype` attribute for columns and arrays as well as an optimization which prunes dtype comparison branches at compile time. 