### PR TITLE
Fix `Caller.__repr__` for JIT without local

### DIFF
--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -66,7 +66,7 @@ def extract_templates(options):
     return new_options, templates
 
 
-class Signature(object):
+class Signature:
     """Signature decorator for Python functions.
 
     A Signature decorator may contain many signature objects
@@ -280,7 +280,7 @@ class Signature(object):
         return signature
 
 
-class Caller(object):
+class Caller:
     """Remote JIT caller, holds the decorated function that can be
     executed remotely.
     """
@@ -377,7 +377,7 @@ class Caller(object):
             return self.remotejit.remote_call(self.func, ftype, arguments)
 
 
-class RemoteJIT(object):
+class RemoteJIT:
     """RemoteJIT is a decorator generator for user functions to be
     remotely JIT compiled.
 
@@ -852,7 +852,7 @@ class DebugDispatcherRJIT(DispatcherRJIT):
     debug = True
 
 
-class LocalClient(object):
+class LocalClient:
     """Pretender of thrift.Client.
 
     All calls will be made in a local process. Useful for debbuging.

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -320,8 +320,7 @@ class Caller:
 
     def __repr__(self):
         msg = (
-            f"{type(self).__name__}({self.func}, {self.signature}, "
-            f"describe={self.describe()})"
+            f"{type(self).__name__}({self.func}, {self.signature})"
         )
         return msg
 

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -319,8 +319,11 @@ class Caller:
         return Caller(self.func, self.signature.local)
 
     def __repr__(self):
-        return '%s(%s, %s, local=%s)' % (type(self).__name__, self.func,
-                                         self.signature, self.local)
+        msg = (
+            f"{type(self).__name__}({self.func}, {self.signature}, "
+            f"describe={self.describe()})"
+        )
+        return msg
 
     def __str__(self):
         return self.describe()

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -319,10 +319,7 @@ class Caller:
         return Caller(self.func, self.signature.local)
 
     def __repr__(self):
-        msg = (
-            f"{type(self).__name__}({self.func}, {self.signature})"
-        )
-        return msg
+        return f"{type(self).__name__}({self.func}, {self.signature})"
 
     def __str__(self):
         return self.describe()

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -300,7 +300,7 @@ class TargetInfo(object):
             return bits
         # expand this dict as needed
         return dict(x86_64=64, nvptx64=64,
-                    x86=32, nvptx=32)[self.arch]
+                    x86=32, nvptx=32, arm64=64)[self.arch]
 
     @property
     def datalayout(self):


### PR DESCRIPTION
Closes #404

* ~Use `Caller.describe` instead of `Caller.local`~
* Add support for `arm64` in `TargetInfo.bits`