### PR TITLE
Support remote calling of run-time UDF/UDTFs from Python

### DIFF
--- a/.github/workflows/rbc_test.yml
+++ b/.github/workflows/rbc_test.yml
@@ -295,7 +295,7 @@ jobs:
         - name: Install additional packages
           shell: bash -l {0}
           run: |
-            mamba install -c conda-forge omniscidb nbval ibis-omniscidb matplotlib pandas ibis-framework=2.0
+            mamba install -c conda-forge omniscidb nbval ibis-omniscidb matplotlib pandas ibis-framework
 
         - name: Start omniscidb server
           shell: bash -l {0}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ from rbc import __version__
 # -- Project information -----------------------------------------------------
 
 project = 'RBC'
-copyright = '2022-%s, Xnd-Project Developers' % datetime.datetime.now().year
+copyright = '2018-%s, Xnd-Project Developers' % datetime.datetime.now().year
 author = 'Xnd-Project Developers'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ from rbc import __version__
 # -- Project information -----------------------------------------------------
 
 project = 'RBC'
-copyright = '2018-%s, Xnd-Project Developers' % datetime.datetime.now().year
+copyright = '2022-%s, Xnd-Project Developers' % datetime.datetime.now().year
 author = 'Xnd-Project Developers'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/notebooks/rbc-intro.ipynb
+++ b/notebooks/rbc-intro.ipynb
@@ -175,9 +175,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "found no matching function type to given argument types:\n",
-      "    float64, float64\n",
-      "  available function types:\n",
+      "found no matching function signature to given argument types:\n",
+      "    (float64, float64) -> ...\n",
+      "  available function signatures:\n",
       "    int64(int64, int64)\n"
      ]
     }

--- a/notebooks/rbc-intro.ipynb
+++ b/notebooks/rbc-intro.ipynb
@@ -49,7 +49,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "staring rpc.thrift server: /home/guilhermel/.conda/envs/rbc/lib/python3.8/site-packages/rbc/remotejit.thrift"
+      "staring rpc.thrift server: /home/pearu/git/xnd-project/rbc/rbc/remotejit.thrift"
      ]
     }
    ],
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,9 +84,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--------------------------------------cpu---------------------------------------\n",
+      "; ModuleID = 'rbc.irtools.compile_to_IR'\n",
+      "source_filename = \"<string>\"\n",
+      "target triple = \"x86_64-unknown-linux-gnu\"\n",
+      "\n",
+      "@_ZN08NumbaEnv8__main__7foo_241B40c8tJTC_2fWQA9HW1CcAv0EjzIkAdRoAEtoAgA_3dExx = common local_unnamed_addr global i8* null\n",
+      "\n",
+      "; Function Attrs: norecurse nounwind readnone\n",
+      "define i64 @foo_lallA(i64 %.1, i64 %.2) local_unnamed_addr #0 {\n",
+      "entry:\n",
+      "  %.6.i = add nsw i64 %.2, %.1\n",
+      "  ret i64 %.6.i\n",
+      "}\n",
+      "\n",
+      "attributes #0 = { norecurse nounwind readnone }\n",
+      "\n",
+      "!llvm.module.flags = !{!0}\n",
+      "\n",
+      "!0 = !{i32 4, !\"pass_column_arguments_by_value\", i1 false}\n",
+      "\n",
+      "--------------------------------------------------------------------------------\n"
+     ]
+    }
+   ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "# Generate LLVM IR, useful for debugging\n",
@@ -95,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +133,7 @@
        "4"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -119,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -128,7 +157,7 @@
        "6"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -139,14 +168,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "found no matching function type to given argument types `float64, float64`. Available function types: int64(int64, int64)\n"
+      "found no matching function type to given argument types:\n",
+      "    float64, float64\n",
+      "  available function types:\n",
+      "    int64(int64, int64)\n"
      ]
     }
    ],
@@ -159,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -179,7 +211,7 @@
        "(1+3.4j)"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -190,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -199,7 +231,7 @@
        "4.2"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,9 +252,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:rbc-dev] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-rbc-dev-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -234,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/rbc-intro.ipynb
+++ b/notebooks/rbc-intro.ipynb
@@ -252,9 +252,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:rbc-dev] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-rbc-dev-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -266,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/rbc-simple.ipynb
+++ b/notebooks/rbc-simple.ipynb
@@ -194,9 +194,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "found no matching function type to given argument types:\n",
-      "    complex128, int64\n",
-      "  available function types:\n",
+      "found no matching function signature to given argument types:\n",
+      "    (complex128, int64) -> ...\n",
+      "  available function signatures:\n",
       "    float64(float64, float64)\n",
       "    int64 add(int64, int64)\n"
      ]

--- a/notebooks/rbc-simple.ipynb
+++ b/notebooks/rbc-simple.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Remote Backend Compiler - RBC\n",
     "\n",
@@ -15,77 +16,77 @@
     "1. decorate Python functions that implementation will be used as a template for low-level functions\n",
     "2. define signatures of the low-level functions\n",
     "3. start/stop remote JIT server"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import warnings; warnings.filterwarnings('ignore')"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import rbc"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Create Remote JIT decorator"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "rjit = rbc.RemoteJIT(host='localhost')"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "One can start the server from a separate process as well as in background of the current process:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "rjit.start_server(background=True)"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "staring rpc.thrift server: /home/guilhermeleobas/git/rbc/rbc/remotejit.thrift"
+      "staring rpc.thrift server: /home/pearu/git/xnd-project/rbc/rbc/remotejit.thrift"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "rjit.start_server(background=True)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The server will be stopped at the end of this notebook, see below."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Use `rjit` as decorator with signature specifications\n",
     "\n",
@@ -97,164 +98,164 @@
     "If a function uses annotations, these are also used for determining the signature of a function.\n",
     "\n",
     "For instance, the following example will define an `add` function for arguments with `int` or `float` type:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "@rjit('f64(f64,f64)')\n",
     "def add(a: int, b: int) -> int:\n",
     "    return a + b"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "#### To view the currently defined signatures"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "source": [
-    "for device, target_info in rjit.targets.items():\n",
-    "    with target_info:\n",
-    "        print('\\n'.join(map(str, add.get_signatures())))"
-   ],
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "float64(float64, float64)\n",
       "int64 add(int64, int64)\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "for device, target_info in rjit.targets.items():\n",
+    "    with target_info:\n",
+    "        print('\\n'.join(map(str, add.get_signatures())))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Try it out:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "source": [
-    "add(1, 2)      # int inputs"
-   ],
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "3"
       ]
      },
+     "execution_count": 7,
      "metadata": {},
-     "execution_count": 8
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "add(1, 2)      # int inputs"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "source": [
-    "add(1.5, 2.0)  # float inputs"
-   ],
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "3.5"
       ]
      },
+     "execution_count": 8,
      "metadata": {},
-     "execution_count": 9
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "add(1.5, 2.0)  # float inputs"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "found no matching function type to given argument types:\n",
+      "    complex128, int64\n",
+      "  available function types:\n",
+      "    float64(float64, float64)\n",
+      "    int64 add(int64, int64)\n"
+     ]
+    }
+   ],
    "source": [
     "try:             # complex inputs\n",
     "    add(1j, 2)   # expect a failure\n",
     "except Exception as msg:\n",
     "    print(msg)"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "found no matching function type to given argument types `complex128, int64`. Available function types: float64(float64, float64); int64 add(int64, int64)\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add support for complex inputs:\n",
+    "_ = add.signature('complex128(complex128, complex128)')"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "source": [
-    "# add support for complex inputs:\n",
-    "_ = add.signature('complex128(complex128, complex128)')"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "source": [
-    "add(1j, 2)  # now it works"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "(2+1j)"
       ]
      },
+     "execution_count": 11,
      "metadata": {},
-     "execution_count": 12
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "add(1j, 2)  # now it works"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Debugging\n",
     "\n",
     "For debugging, one can view the generated LLVM IR using the `add.describe` method or just printing the `add` object:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "print(add)"
-   ],
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "--------------------------------------cpu---------------------------------------\n",
@@ -262,9 +263,9 @@
       "source_filename = \"<string>\"\n",
       "target triple = \"x86_64-unknown-linux-gnu\"\n",
       "\n",
-      "@\"_ZN08NumbaEnv8__main__7add$244Edd\" = common local_unnamed_addr global i8* null\n",
-      "@\"_ZN08NumbaEnv8__main__7add$245E10complex12810complex128\" = common local_unnamed_addr global i8* null\n",
-      "@\"_ZN08NumbaEnv8__main__7add$246Exx\" = common local_unnamed_addr global i8* null\n",
+      "@_ZN08NumbaEnv8__main__7add_244B40c8tJTC_2fWQA9HW1CcAv0EjzIkAdRoAEtoAgA_3dEdd = common local_unnamed_addr global i8* null\n",
+      "@_ZN08NumbaEnv8__main__7add_245B40c8tJTC_2fWQA9HW1CcAv0EjzIkAdRoAEtoAgA_3dE10complex12810complex128 = common local_unnamed_addr global i8* null\n",
+      "@_ZN08NumbaEnv8__main__7add_246B40c8tJTC_2fWQA9HW1CcAv0EjzIkAdRoAEtoAgA_3dExx = common local_unnamed_addr global i8* null\n",
       "\n",
       "; Function Attrs: norecurse nounwind readnone\n",
       "define double @add_daddA(double %.1, double %.2) local_unnamed_addr #0 {\n",
@@ -304,37 +305,44 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "print(add)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Stopping the RBC server"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "source": [
-    "rjit.stop_server()"
-   ],
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "... stopping rpc.thrift server\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "rjit.stop_server()"
+   ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "d5f7c970bbb39fa37ad8320758958011db57178b67e8623b46fd6c0065ba8519"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.12 64-bit ('rbc': conda)"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -346,10 +354,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
-  },
-  "interpreter": {
-   "hash": "d5f7c970bbb39fa37ad8320758958011db57178b67e8623b46fd6c0065ba8519"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/rbc/omnisci_backend/omnisci_bytes.py
+++ b/rbc/omnisci_backend/omnisci_bytes.py
@@ -25,6 +25,14 @@ class OmnisciBytesType(OmnisciBufferType):
     def buffer_extra_members(self):
         return ('bool is_null',)
 
+    def match(self, other):
+        if type(self) is type(other):
+            return self[0] == other[0]
+        if other.is_pointer and other[0].is_char and other[0].bits == 8:
+            return 1
+        if other.is_string:
+            return 2
+
 
 BytesPointer = BufferPointer
 

--- a/rbc/omnisci_backend/omnisci_column.py
+++ b/rbc/omnisci_backend/omnisci_column.py
@@ -114,7 +114,10 @@ class OmnisciCursorType(typesystem.Type):
         params = []
         for p in args[0]:
             if not isinstance(p, (OmnisciColumnType, OmnisciColumnListType)):
-                p = OmnisciColumnType((p,))
+                # map Cursor<T ...> to Cursor<Column<T> ...>
+                c = p.copy()
+                p = OmnisciColumnType((c,), **c._params)
+                c._params.clear()
             params.append(p)
         return (tuple(params),)
 

--- a/rbc/omnisci_backend/omnisci_column.py
+++ b/rbc/omnisci_backend/omnisci_column.py
@@ -26,6 +26,10 @@ class OmnisciColumnType(OmnisciBufferType):
         omnisci_version = TargetInfo().software[1][:3]
         return omnisci_version <= (5, 7, 0)
 
+    def match(self, other):
+        if type(self) is type(other):
+            return self[0] == other[0]
+
 
 class OmnisciOutputColumnType(OmnisciColumnType):
     """Omnisci OutputColumn type for RBC typesystem.

--- a/rbc/omnisci_backend/omnisci_text_encoding.py
+++ b/rbc/omnisci_backend/omnisci_text_encoding.py
@@ -11,7 +11,7 @@ class OmnisciTextEncodingDictType(typesystem.Type):
     """Omnisci Text Encoding Dict type for RBC typesystem.
     """
 
-    def tostring(self, use_typename=False, use_annotation=True):
+    def tostring(self, **options):
         return 'TextEncodingDict'
 
     @property

--- a/rbc/omnisci_backend/omnisci_text_encoding.py
+++ b/rbc/omnisci_backend/omnisci_text_encoding.py
@@ -11,9 +11,6 @@ class OmnisciTextEncodingDictType(typesystem.Type):
     """Omnisci Text Encoding Dict type for RBC typesystem.
     """
 
-    def tostring(self, **options):
-        return 'TextEncodingDict'
-
     @property
     def __typesystem_type__(self):
         return typesystem.Type('int32')

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -819,6 +819,8 @@ class RemoteOmnisci(RemoteJIT):
                 ('int64', 'int64_t'),
                 ('float32', 'float'),
                 ('float64', 'double'),
+                ('TextEncodingDict', 'TextEncodingDict'),
+                ('OmnisciTextEncodingDictType<>', 'TextEncodingDict'),
         ]:
             ext_arguments_map['OmnisciArrayType<%s>' % ptr_type] \
                 = ext_arguments_map.get('Array<%s>' % T)
@@ -832,15 +834,6 @@ class RemoteOmnisci(RemoteJIT):
                 = ext_arguments_map.get('ColumnList<%s>' % T)
 
         ext_arguments_map['OmnisciBytesType<char8>'] = ext_arguments_map.get('Bytes')
-
-        ext_arguments_map['OmnisciColumnType<TextEncodingDict>'] \
-            = ext_arguments_map.get('Column<TextEncodingDict>')
-        ext_arguments_map['OmnisciOutputColumnType<TextEncodingDict>'] \
-            = ext_arguments_map.get('Column<TextEncodingDict>')
-        ext_arguments_map['OmnisciColumnListType<TextEncodingDict>'] \
-            = ext_arguments_map.get('ColumnList<TextEncodingDict>')
-        # ext_arguments_map['OmnisciOutputColumnListType<%s>' % size] \
-        #     = ext_arguments_map.get('ColumnList<%s>' % size)
 
         values = list(ext_arguments_map.values())
         for v, n in thrift.TExtArgumentType._VALUES_TO_NAMES.items():

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -230,6 +230,8 @@ output_buffer_sizer_map = dict(
     Constant='kConstant',
     SpecifiedParameter='kTableFunctionSpecifiedParameter',
     PreFlight='kPreFlightParameter')
+
+# Default sizer is RowMultiplier:
 output_buffer_sizer_map[None] = output_buffer_sizer_map['RowMultiplier']
 
 user_specified_output_buffer_sizers = {
@@ -988,8 +990,6 @@ class RemoteOmnisci(RemoteJIT):
                 if not (a.is_int and a.bits == 32):
                     raise ValueError(
                         'sizer argument must have type int32')
-                if _sizer is None:
-                    _sizer = 'RowMultiplier'
                 _sizer = output_buffer_sizer_map[_sizer]
                 # cannot have multiple sizer arguments
                 assert sizer_index == -1

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -1328,6 +1328,9 @@ class RemoteOmnisci(RemoteJIT):
         elif isinstance(typ, OmnisciArrayType):
             p = tuple(map(self.format_type, typ[0]))
             typ = typesystem.Type(('Array',) + p, **typ._params)
+        elif isinstance(typ, OmnisciCursorType):
+            p = tuple(map(self.format_type, typ[0]))
+            typ = typesystem.Type(('Cursor',) + p, **typ._params)
         elif isinstance(typ, OmnisciBytesType):
             typ = typ.copy().params(typename='Bytes')
             use_typename = True

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -437,8 +437,8 @@ class RemoteDispatcher:
             lines = self.remotejit._format_available_function_types(available_types_devices)
             available = '\n    ' + '\n    '.join(lines)
             satypes = ', '.join(map(str, atypes))
-            raise TypeError(f'found no matching function type to given argument types:'
-                            f'\n    {satypes}\n  available function types:{available}')
+            raise TypeError(f'found no matching function signature to given argument types:'
+                            f'\n    ({satypes}) -> ...\n  available function signatures:{available}')
 
         _, device, caller_id, ftype = penalty_device_caller_ftype[0]
         target_info = self.remotejit.targets[device]

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -420,7 +420,7 @@ class CommonNameCallers:
 
         if not penalty_device_caller_ftype:
             raise TypeError(f'found no matching function type to given argument types:'
-                            ' function name={self.name}, (arguments={arguments}')
+                            f' function name={self.name}, (arguments={arguments}')
 
         _, device, caller_id, ftype = penalty_device_caller_ftype[0]
         target_info = self.remotejit.targets[device]

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -377,7 +377,8 @@ class Caller:
     def __call__(self, *arguments, device=UNSPECIFIED, hold=UNSPECIFIED):
         """Return the result of a remote JIT compiled function call.
         """
-        return RemoteDispatcher(self.func.__name__, [self])(*arguments, device=device, hold=hold)
+        caller = self.remotejit.get_caller(self.func.__name__)
+        return caller(*arguments, device=device, hold=hold)
 
 
 class RemoteDispatcher:

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -437,8 +437,9 @@ class RemoteDispatcher:
             lines = self.remotejit._format_available_function_types(available_types_devices)
             available = '\n    ' + '\n    '.join(lines)
             satypes = ', '.join(map(str, atypes))
-            raise TypeError(f'found no matching function signature to given argument types:'
-                            f'\n    ({satypes}) -> ...\n  available function signatures:{available}')
+            raise TypeError(
+                f'found no matching function signature to given argument types:'
+                f'\n    ({satypes}) -> ...\n  available function signatures:{available}')
 
         _, device, caller_id, ftype = penalty_device_caller_ftype[0]
         target_info = self.remotejit.targets[device]

--- a/rbc/tests/__init__.py
+++ b/rbc/tests/__init__.py
@@ -4,7 +4,22 @@ __all__ = ['omnisci_fixture', 'sql_execute']
 import os
 import pytest
 import warnings
+import numpy
 from collections import defaultdict
+
+
+def assert_equal(actual, desired):
+    """Test equality of actual and desired.
+
+    When both inputs are numpy array or number objects, test equality
+    of dtype attributes as well.
+    """
+    numpy.testing.assert_equal(actual, desired)
+
+    if isinstance(actual, numpy.ndarray) and isinstance(desired, numpy.ndarray):
+        numpy.testing.assert_equal(actual.dtype, desired.dtype)
+    elif isinstance(actual, numpy.number) and isinstance(desired, numpy.number):
+        numpy.testing.assert_equal(actual.dtype, desired.dtype)
 
 
 def sql_execute(query):

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from rbc.errors import UnsupportedError
 from rbc.tests import omnisci_fixture, assert_equal
+from rbc.typesystem import Type
 
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
 available_version, reason = rbc_omnisci.is_available()
@@ -733,3 +734,67 @@ def test_truncate_issue(omnisci):
         ' from {omnisci.table_name} limit 1'
         .format(**locals()))
     assert list(result)[0] == (64,)
+
+
+def test_format_type(omnisci):
+    def test(s, caller=False):
+        with omnisci.targets['cpu']:
+            with Type.alias(**omnisci.typesystem_aliases):
+                typ = Type.fromobject(s)
+                if caller:
+                    typ = omnisci.caller_signature(typ)
+                return omnisci.format_type(typ)
+
+    assert test('int32 x') == 'int32 x'
+    assert test('Column<int32 x | name=y>') == 'Column<int32 x | name=y>'
+    assert test('Column<int32 | name=y>') == 'Column<int32 y>'
+    assert test('Column<int32 x>') == 'Column<int32 x>'
+    assert test('Column<int32>') == 'Column<int32>'
+    assert test('Column<int32> z') == 'Column<int32> z'
+    assert test('Column<int32> | name=z') == 'Column<int32> z'
+    assert test('Column<int32> x | name=z') == 'Column<int32> x | name=z'
+    assert test('Column<Bytes>') == 'Column<Bytes>'
+    assert test('Column<Array<int32>>') == 'Column<Array<int32>>'
+    assert test('Column<Array<Bytes>>') == 'Column<Array<Bytes>>'
+
+    assert test('OutputColumn<int32>') == 'OutputColumn<int32>'
+    assert test('ColumnList<int32>') == 'ColumnList<int32>'
+
+    assert test('UDTF(ColumnList<int32>)') == 'UDTF(ColumnList<int32>)'
+    assert test('int32(ColumnList<int32>)') == 'UDTF(ColumnList<int32>)'
+    assert (test('UDTF(int32 x, Column<float32> y, OutputColumn<int64> z)')
+            == 'UDTF(int32 x, Column<float32> y, OutputColumn<int64> z)')
+    assert test('UDTF(RowMultiplier)') == 'UDTF(RowMultiplier)'
+    assert test('UDTF(RowMultiplier m)') == 'UDTF(RowMultiplier m)'
+    assert test('UDTF(RowMultiplier | name=m)') == 'UDTF(RowMultiplier m)'
+    assert test('UDTF(Constant m)') == 'UDTF(Constant m)'
+    assert test('UDTF(ConstantParameter m)') == 'UDTF(ConstantParameter m)'
+    assert test('UDTF(SpecifiedParameter m)') == 'UDTF(SpecifiedParameter m)'
+    assert test('UDTF(PreFlight m)') == 'UDTF(PreFlight m)'
+    assert test('UDTF(TableFunctionManager mgr)') == 'UDTF(TableFunctionManager mgr)'
+
+    assert test('int32(int32)') == '(int32) -> int32'
+    assert test('int32(int32 x)') == '(int32 x) -> int32'
+    assert test('int32(Array<int32>)') == '(Array<int32>) -> int32'
+    assert test('int32(int32[])') == '(Array<int32>) -> int32'
+    assert test('int32(Array<int32> x)') == '(Array<int32> x) -> int32'
+    assert test('int32(Bytes)') == '(Bytes) -> int32'
+    assert test('int32(Bytes x)') == '(Bytes x) -> int32'
+    assert test('int32(TextEncodingDict)') == '(TextEncodingDict) -> int32'
+    assert test('int32(TextEncodingDict x)') == '(TextEncodingDict x) -> int32'
+    assert test('int32(Array<Bytes> x)') == '(Array<Bytes> x) -> int32'
+
+    def test2(s):
+        return test(s, caller=True)
+    assert test2('UDTF(int32, OutputColumn<int32>)') == '(int32) -> (Column<int32>)'
+    assert test2('UDTF(OutputColumn<int32>)') == '(void) -> (Column<int32>)'
+    assert (test2('UDTF(int32 | sizer, OutputColumn<int32>)')
+            == '(RowMultiplier) -> (Column<int32>)')
+    assert (test2('UDTF(ConstantParameter, OutputColumn<int32>)')
+            == '(ConstantParameter) -> (Column<int32>)')
+    assert test2('UDTF(SpecifiedParameter, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
+    assert test2('UDTF(Constant, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
+    assert test2('UDTF(PreFlight, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
+    assert test2('UDTF(TableFunctionManager, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
+    assert (test2('UDTF(RowMultiplier, OutputColumn<Array<Bytes>>)')
+            == '(RowMultiplier) -> (Column<Array<Bytes>>)')

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -1,9 +1,10 @@
 import os
 import itertools
 import pytest
+import numpy as np
 
 from rbc.errors import UnsupportedError
-from rbc.tests import omnisci_fixture
+from rbc.tests import omnisci_fixture, assert_equal
 
 rbc_omnisci = pytest.importorskip('rbc.omniscidb')
 available_version, reason = rbc_omnisci.is_available()
@@ -72,9 +73,7 @@ def test_direct_call(omnisci):
     def farenheight2celcius(f):
         return (f - 32) * 5 / 9
 
-    msg = "Cannot call functions"
-    with pytest.raises(UnsupportedError, match=msg):
-        farenheight2celcius(40)
+    assert_equal(farenheight2celcius(40), np.float32(40 / 9))
 
 
 def test_local_caller(omnisci):

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -772,6 +772,10 @@ def test_format_type(omnisci):
     assert test('UDTF(SpecifiedParameter m)') == 'UDTF(SpecifiedParameter m)'
     assert test('UDTF(PreFlight m)') == 'UDTF(PreFlight m)'
     assert test('UDTF(TableFunctionManager mgr)') == 'UDTF(TableFunctionManager mgr)'
+    assert test('UDTF(Cursor<int32, float64>)') == 'UDTF(Cursor<Column<int32>, Column<float64>>)'
+    assert test('UDTF(Cursor<int32 x>)') == 'UDTF(Cursor<Column<int32> x>)'
+    assert test('UDTF(Cursor<int32 | name=x>)') == 'UDTF(Cursor<Column<int32> x>)'
+    assert test('UDTF(Cursor<Bytes x>)') == 'UDTF(Cursor<Column<Bytes> x>)'
 
     assert test('int32(int32)') == '(int32) -> int32'
     assert test('int32(int32 x)') == '(int32 x) -> int32'
@@ -786,6 +790,7 @@ def test_format_type(omnisci):
 
     def test2(s):
         return test(s, caller=True)
+
     assert test2('UDTF(int32, OutputColumn<int32>)') == '(int32) -> (Column<int32>)'
     assert test2('UDTF(OutputColumn<int32>)') == '(void) -> (Column<int32>)'
     assert (test2('UDTF(int32 | sizer, OutputColumn<int32>)')
@@ -798,3 +803,6 @@ def test_format_type(omnisci):
     assert test2('UDTF(TableFunctionManager, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
     assert (test2('UDTF(RowMultiplier, OutputColumn<Array<Bytes>>)')
             == '(RowMultiplier) -> (Column<Array<Bytes>>)')
+
+    assert test2('UDTF(Cursor<int32>)') == '(Cursor<Column<int32>>) -> void'
+    assert test2('UDTF(Cursor<int32 x>)') == '(Cursor<Column<int32> x>) -> void'

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -73,7 +73,7 @@ def test_direct_call(omnisci):
     def farhenheit2celcius(f):
         return (f - 32) * 5 / 9
 
-    assert_equal(farhenheit2celcius(40), np.float32(40 / 9))
+    assert_equal(farhenheit2celcius(40).execute(), np.float32(40 / 9))
 
 
 def test_local_caller(omnisci):

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -70,10 +70,10 @@ def test_direct_call(omnisci):
     omnisci.reset()
 
     @omnisci('double(double)')
-    def farenheight2celcius(f):
+    def farhenheit2celcius(f):
         return (f - 32) * 5 / 9
 
-    assert_equal(farenheight2celcius(40), np.float32(40 / 9))
+    assert_equal(farhenheit2celcius(40), np.float32(40 / 9))
 
 
 def test_local_caller(omnisci):

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -19,7 +19,7 @@ def define(omnisci):
 
     T = ['int64', 'float64', 'int32']
 
-    @omnisci('UDTF(int32 | name=size, T, OutputColumn<T> | name=x)', T=T, devices=['cpu'])
+    @omnisci('UDTF(int32 size, T x0, OutputColumn<T> x)', T=T, devices=['cpu'])
     def arange(size, x0, x):
         set_output_row_size(size)
         for i in range(size):
@@ -28,7 +28,7 @@ def define(omnisci):
 
     T = ['int64', 'float32']
 
-    @omnisci('UDTF(Column<T> | name=x, T, OutputColumn<T> | name=y)', T=T, devices=['cpu'])
+    @omnisci('UDTF(Column<T> x, T dx, OutputColumn<T> y)', T=T, devices=['cpu'])
     def aincr(x, dx, y):
         size = len(x)
         set_output_row_size(size)

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -190,3 +190,17 @@ found no matching function signature to given argument types:
     - UDTF(int32 size, int32 x0, OutputColumn<int32> x)''')
     else:
         assert 0  # expected TypeError
+
+
+def test_remote_udf_overload(omnisci):
+
+    @omnisci('int32(int32)')  # noqa: F811
+    def incr_ol(x):           # noqa: F811
+        return x + 1
+
+    @omnisci('int32(int32, int32)')  # noqa: F811
+    def incr_ol(x, dx):              # noqa: F811
+        return x + dx
+
+    assert incr_ol(1).execute() == 2
+    assert incr_ol(1, 2).execute() == 3

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -18,6 +18,7 @@ def define(omnisci):
         return x + 1
 
     T = ['int64', 'float64', 'int32']
+
     @omnisci('UDTF(int32 | name=size, T, OutputColumn<T> | name=x)', T=T, devices=['cpu'])
     def arange(size, x0, x):
         set_output_row_size(size)
@@ -26,6 +27,7 @@ def define(omnisci):
         return size
 
     T = ['int64', 'float32']
+
     @omnisci('UDTF(Column<T> | name=x, T, OutputColumn<T> | name=y)', T=T, devices=['cpu'])
     def aincr(x, dx, y):
         size = len(x)

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -6,7 +6,7 @@ from rbc.tests import omnisci_fixture, assert_equal
 
 @pytest.fixture(scope='module')
 def omnisci():
-    for o in omnisci_fixture(globals()):
+    for o in omnisci_fixture(globals(), minimal_version=(5, 8)):
         define(o)
         yield o
 

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -45,12 +45,13 @@ def test_udf_string_repr(omnisci):
     assert_equal(str(myincr), "myincr['T(T), T=int32|int64|float32|float64']")
 
     assert_equal(repr(myincr(5)),
-                 "OmnisciQueryCapsule('myincr(CAST(5 AS BIGINT))')")
-    assert_equal(str(myincr(5)), "myincr(CAST(5 AS BIGINT))")
+                 "OmnisciQueryCapsule('SELECT myincr(CAST(5 AS BIGINT))')")
+    assert_equal(str(myincr(5)), "SELECT myincr(CAST(5 AS BIGINT))")
 
     assert_equal(repr(myincr(myincr(5))),
-                 "OmnisciQueryCapsule('myincr(CAST(myincr(CAST(5 AS BIGINT)) AS BIGINT))')")
-    assert_equal(str(myincr(myincr(5))), "myincr(CAST(myincr(CAST(5 AS BIGINT)) AS BIGINT))")
+                 "OmnisciQueryCapsule('SELECT myincr(CAST(myincr(CAST(5 AS BIGINT)) AS BIGINT))')")
+    assert_equal(str(myincr(myincr(5))),
+                 "SELECT myincr(CAST(myincr(CAST(5 AS BIGINT)) AS BIGINT))")
 
 
 def test_udtf_string_repr(omnisci):
@@ -73,7 +74,7 @@ def test_udtf_string_repr(omnisci):
 def test_remote_udf_evaluation(omnisci):
     myincr = omnisci.get_caller('myincr')
 
-    assert_equal(str(myincr(3)), 'myincr(CAST(3 AS BIGINT))')
+    assert_equal(str(myincr(3)), 'SELECT myincr(CAST(3 AS BIGINT))')
     assert_equal(myincr(3, hold=False), 4)
     assert_equal(myincr(3).execute(), 4)
 
@@ -104,8 +105,8 @@ def test_remote_composite_udf_evaluation(omnisci):
     myincr = omnisci.get_caller('myincr')
 
     assert_equal(str(myincr(myincr(3))),
-                 'myincr(CAST(myincr(CAST(3 AS BIGINT)) AS BIGINT))')
-    assert_equal(str(myincr(myincr(3, hold=False))), 'myincr(CAST(4 AS BIGINT))')
+                 'SELECT myincr(CAST(myincr(CAST(3 AS BIGINT)) AS BIGINT))')
+    assert_equal(str(myincr(myincr(3, hold=False))), 'SELECT myincr(CAST(4 AS BIGINT))')
     assert_equal(myincr(myincr(3), hold=False), 5)
     assert_equal(myincr(myincr(3)).execute(), 5)
 

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -162,9 +162,9 @@ def test_remote_udf_typeerror(omnisci):
         myincr("abc")
     except TypeError as msg:
         assert_equal(str(msg), '''\
-found no matching function type to given argument types:
-    string
-  available function types:
+found no matching function signature to given argument types:
+    (string) -> ...
+  available function signatures:
     (int32) -> int32
     (int64) -> int64
     (float32) -> float32
@@ -179,9 +179,9 @@ def test_remote_udtf_typeerror(omnisci):
         arange(1.2, 0)
     except TypeError as msg:
         assert_equal(str(msg), '''\
-found no matching function type to given argument types:
-    float64, int64
-  available function types:
+found no matching function signature to given argument types:
+    (float64, int64) -> ...
+  available function signatures:
     (int32 size, int64 x0) -> (Column<int64> x)
     - UDTF(int32 size, int64 x0, OutputColumn<int64> x)
     (int32 size, float64 x0) -> (Column<float64> x)

--- a/rbc/tests/test_omnisci_caller.py
+++ b/rbc/tests/test_omnisci_caller.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+from rbc.externals.omniscidb import set_output_row_size
+from rbc.tests import omnisci_fixture, assert_equal
+
+
+@pytest.fixture(scope='module')
+def omnisci():
+    for o in omnisci_fixture(globals()):
+        define(o)
+        yield o
+
+
+def define(omnisci):
+
+    @omnisci('T(T)', T=['int32', 'int64', 'float32', 'float64'])
+    def myincr(x):
+        return x + 1
+
+    T = ['int64', 'float64', 'int32']
+    @omnisci('UDTF(int32 | name=size, T, OutputColumn<T> | name=x)', T=T, devices=['cpu'])
+    def arange(size, x0, x):
+        set_output_row_size(size)
+        for i in range(size):
+            x[i] = x0 + x.dtype(i)
+        return size
+
+    T = ['int64', 'float32']
+    @omnisci('UDTF(Column<T> | name=x, T, OutputColumn<T> | name=y)', T=T, devices=['cpu'])
+    def aincr(x, dx, y):
+        size = len(x)
+        set_output_row_size(size)
+        for i in range(size):
+            y[i] = x[i] + dx
+        return size
+
+
+def test_remote_udf_evaluation(omnisci):
+    myincr = omnisci.get_caller('myincr')
+
+    assert myincr(3) == 4
+    assert myincr(3.5) == 4.5
+
+    assert_equal(myincr(np.int64(3)), np.int64(4))
+    # The following test fails because SELECT seems to upcast int32 to
+    # int64. TODO: investigate.
+    # assert_equal(myincr(np.int32(3)), np.int32(4))
+
+    assert_equal(myincr(np.float32(3.5)), np.float32(4.5))
+    # The following test fails because SELECT seems to downcast
+    # float64 to float32. TODO: investigate.
+    # assert_equal(myincr(np.float64(3.5)), np.float64(4.5))
+
+
+def test_remote_udtf_evaluation(omnisci):
+    arange = omnisci.get_caller('arange')
+
+    assert_equal(str(arange(3, 1)),
+                 'Query(SELECT x FROM TABLE(arange(CAST(3 AS INT), CAST(1 AS BIGINT))))')
+
+    assert_equal(arange(3, 1)['x'], list(np.arange(3, dtype=np.int64) + 1))
+    assert_equal(arange(3, 1.5)['x'], list(np.arange(3, dtype=np.float64) + 1.5))
+    assert_equal(arange(np.int32(3), 1)['x'], list(np.arange(3, dtype=np.int32) + 1))
+
+    assert_equal(arange(3, np.float32(1))['x'], np.arange(3, dtype=np.float32) + 1)
+    # The following test fails because SELECT seems to downcast
+    # float64 to float32. TODO: investigate.
+    # assert_equal(arange(3, np.float64(1))['x'], np.arange(3, dtype=np.float64) + 1)
+
+    assert_equal(arange(3, np.int64(1))['x'], np.arange(3, dtype=np.int64) + 1)
+    # The following test fails because SELECT seems to upcast int32 to
+    # int64. TODO: investigate.
+    # assert_equal(arange(3, np.int32(1))['x'], np.arange(3, dtype=np.int32) + 1)
+
+
+def test_remote_composite_udtf_evaluation(omnisci):
+    arange = omnisci.get_caller('arange')
+    aincr = omnisci.get_caller('aincr')
+
+    r = aincr(arange(3, 1), 2)
+
+    assert_equal(str(r), 'Query(SELECT y FROM TABLE(aincr(CURSOR(SELECT x FROM'
+                 ' TABLE(arange(CAST(3 AS INT), CAST(1 AS BIGINT)))), CAST(2 AS BIGINT))))')
+
+    r = r.execute()
+
+    assert_equal(r['y'], np.arange(3, dtype=np.int64) + 1 + 2)

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -214,6 +214,7 @@ def test_composition(rjit):
 
 @with_localjit
 def test_templates(ljit):
+    ljit.reset()
 
     assert isinstance(ljit, RemoteJIT)
 
@@ -322,6 +323,8 @@ scalar_pointer_types = ['int64', 'int32', 'int16', 'int8', 'float32', 'float64',
 @pytest.mark.parametrize("T", scalar_pointer_types)
 @pytest.mark.parametrize("V", scalar_pointer_types)
 def test_scalar_pointer_conversion(rjit, T, V):
+    rjit.reset()
+
     with Type.alias(T=T, V=V, intp='int64'):
 
         # pointer-intp conversion
@@ -463,6 +466,7 @@ def test_scalar_pointer_conversion(rjit, T, V):
 
 @pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
 def test_scalar_pointer_access_local(ljit, T):
+    ljit.reset()
 
     with Type.alias(T=T):
         arr = np.array([1, 2, 3, 4], dtype=T)
@@ -503,6 +507,8 @@ memory_managers = dict(
 @pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
 @pytest.mark.parametrize("memman", list(memory_managers))
 def test_scalar_pointer_access_remote(rjit, memman, T):
+    rjit.reset()
+
     calloc_prototype, free_prototype = memory_managers[memman]
 
     with Type.alias(T=T):
@@ -548,6 +554,7 @@ def test_scalar_pointer_access_remote(rjit, memman, T):
 @pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
 def test_struct_input(ljit, rjit, location, T):
     jit = rjit if location == 'remote' else ljit
+    jit.reset()
 
     S = '{T x, T y, T z}'
 
@@ -695,6 +702,7 @@ def test_struct_input(ljit, rjit, location, T):
 @pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
 def test_struct_pointer_members(ljit, rjit, location, T):
     jit = rjit if location == 'remote' else ljit
+    jit.reset()
 
     index_t = 'int32'
     S = '{T* data, index_t size}'
@@ -779,6 +787,7 @@ def test_struct_pointer_members(ljit, rjit, location, T):
 @pytest.mark.parametrize("T", ['int64', 'int32', 'int16', 'int8', 'float32', 'float64'])
 def test_struct_double_pointer_members(ljit, rjit, location, T):
     jit = rjit if location == 'remote' else ljit
+    jit.reset()
 
     index_t = 'int32'
     S = '{T** data, index_t length, index_t size}'

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -161,7 +161,7 @@ def test_rjit_add(rjit):
 
     with pytest.raises(
             TypeError,
-            match=r'found no matching function type to given argument types'):
+            match=r'found no matching function signature to given argument types'):
         add(1, 2.5)
 
     add.signature('d(d,d)')
@@ -174,7 +174,7 @@ def test_rjit_add(rjit):
 
     with pytest.raises(
             TypeError,
-            match=r'found no matching function type to given argument types'):
+            match=r'found no matching function signature to given argument types'):
         add(1j, 2)
 
     add.signature('c128(c128,c128)')

--- a/rbc/tests/test_typesystem.py
+++ b/rbc/tests/test_typesystem.py
@@ -622,3 +622,11 @@ def test_get_signature_ufunc(target_info):
 
     sig = get_signature(np.modf)
     assert len(sig.parameters) == 3
+
+
+def test_copy(target_info):
+    t = Type.fromstring('int foo| a = 1')
+    t2 = t.copy()
+    t.annotation(b=1)
+    assert str(t) == 'int32 foo | a=1 | b=1'
+    assert str(t2) == 'int32 foo | a=1'

--- a/rbc/thrift/server.py
+++ b/rbc/thrift/server.py
@@ -131,7 +131,7 @@ class Server(object):
             except ConnectionRefusedError:
                 time.sleep(0.5)
             except Exception as msg:
-                print(f'Connection failed: `{msg}`, trying again in 0.5 secs..')
+                warnings.info(f'Connection failed: `{msg}`, trying again in 0.5 secs..')
                 time.sleep(0.5)
             else:
                 break
@@ -145,8 +145,9 @@ class Server(object):
                 f' (was alive={is_alive}, startup time={startup_time}s,'
                 f' elapsed time={time.time() - start})')
         if number_of_tries > 1:
-            print(f'More than one try ({number_of_tries}) in starting up rpc_thrift_server.'
-                  f' Total elapsed time is {time.time() - start} seconds.')
+            warnings.info(
+                f'More than one try ({number_of_tries}) in starting up rpc_thrift_server.'
+                f' Total elapsed time is {time.time() - start} seconds.')
         return p
 
     def _serve(self):

--- a/rbc/thrift/server.py
+++ b/rbc/thrift/server.py
@@ -131,7 +131,7 @@ class Server(object):
             except ConnectionRefusedError:
                 time.sleep(0.5)
             except Exception as msg:
-                warnings.info(f'Connection failed: `{msg}`, trying again in 0.5 secs..')
+                warnings.warn(f'Connection failed: `{msg}`, trying again in 0.5 secs..')
                 time.sleep(0.5)
             else:
                 break
@@ -145,7 +145,7 @@ class Server(object):
                 f' (was alive={is_alive}, startup time={startup_time}s,'
                 f' elapsed time={time.time() - start})')
         if number_of_tries > 1:
-            warnings.info(
+            warnings.warn(
                 f'More than one try ({number_of_tries}) in starting up rpc_thrift_server.'
                 f' Total elapsed time is {time.time() - start} seconds.')
         return p

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -411,6 +411,13 @@ class Type(tuple, metaclass=MetaType):
                 'attempt to create an invalid Type object from `%s`' % (args,))
         return obj.postprocess_type()
 
+    def copy(self, cls=None):
+        """Return a copy of type.
+        """
+        if cls is None:
+            cls = type(self)
+        return cls(*self, **self._params)
+
     @classmethod
     def preprocess_args(cls, args):
         """Preprocess the arguments of Type constructor.
@@ -1469,6 +1476,15 @@ class Type(tuple, metaclass=MetaType):
             elif self.is_pointer and (other.is_int or other.is_uint):
                 if self.bits == other.bits:
                     return 1
+                return
+            elif self.is_custom:
+                if type(self) is not type(other):
+                    return
+                if self[0] == other[0]:
+                    return 0
+                # WARNING: if the state of custom type depends on
+                # params or annotations then it must re-define match
+                # method accordingly.
                 return
             # TODO: lots of
             raise NotImplementedError(repr((self, other)))

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -1411,6 +1411,16 @@ class Type(tuple, metaclass=MetaType):
                 return 0
             if other.is_void:
                 return (0 if self.is_void else None)
+            elif self.is_custom:
+                if type(self) is not type(other):
+                    return
+                if self[0] == other[0]:
+                    if self._params or other._params:
+                        warnings.warn(
+                            'The default match implementation ignores _params content. Please'
+                            f' implement match method for custom type {type(self).__name__}')
+                    return 1
+                return
             elif other.is_pointer:
                 if not self.is_pointer:
                     return
@@ -1496,15 +1506,7 @@ class Type(tuple, metaclass=MetaType):
             elif ((self.is_string and not other.is_string)
                   or (not self.is_string and other.is_string)):
                 return
-            elif self.is_custom:
-                if type(self) is not type(other):
-                    return
-                if self[0] == other[0]:
-                    return 0
-                # WARNING: if the state of custom type depends on
-                # params or annotations then it must re-define match
-                # method accordingly.
-                return
+
             # TODO: lots of
             raise NotImplementedError(repr((self, other)))
         elif isinstance(other, tuple):

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -1524,8 +1524,8 @@ class Type(tuple, metaclass=MetaType):
             yield self
         elif self.is_atomic:
             type_list = templates.get(self[0])
-            assert isinstance(type_list, list), type_list
             if type_list:
+                assert isinstance(type_list, list), type_list
                 for i, t in enumerate(type_list):
                     # using copy so that template symbols will not be
                     # contaminated with self parameters

--- a/rbc/utils.py
+++ b/rbc/utils.py
@@ -235,3 +235,7 @@ def check_returns_none(func):
         last_instr = instr
 
     return True
+
+
+DEFAULT = object()
+UNSPECIFIED = object()

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+cffi
 numba>=0.52
 llvmlite>=0.29
 tblib


### PR DESCRIPTION
As in the title.

Too many new RBC users (current count is 2) have fallen into the trap of calling omnisci decorated functions from Python.

So, this PR now implements basic support for calling UDFs and UDTFs from Python. Example:

```python
In [1]: from rbc.omniscidb import RemoteOmnisci, get_client_config

In [2]: from rbc.externals.omniscidb import set_output_row_size

In [3]: omnisci = RemoteOmnisci(**get_client_config())

In [4]: @omnisci('UDTF(int32, OutputColumn<int64> x)')
   ...: def arange(size, x):
   ...:     set_output_row_size(size)
   ...:     for i in range(size):
   ...:         x[i] = i
   ...:     return size
   ...: 

In [5]: arange
Out[5]: Caller(<function arange at 0x7f31aaa03b70>, Signature('UDTF(int32, OutputColumn<int64> x)'))

In [6]: print(arange)
arange['UDTF(int32, OutputColumn<int64> x)']

In [7]: arange(5)
Out[7]: OmnisciQueryCapsule('SELECT x FROM TABLE(arange(CAST(5 AS INT)))')

In [8]: arange(5).execute()
Out[8]: 
rec.array([(0,), (1,), (2,), (3,), (4,)],
          dtype=[('x', '<i8')])
In [15]: arange(5)['x']
Out[15]: array([0, 1, 2, 3, 4])

In [16]: arange(5.5)
<snip>
TypeError: found no matching function signature to given argument types:
    (float64) -> ...
  available function signatures:
    (int32) -> (Column<int64> x)
    - UDTF(int32, OutputColumn<int64> x)
```

Notice that `arange(5)` returns a `OmnisciQueryCapsule` instance that can be executed using `execute()` method. In the return, the output columns are collected into a numpy.recarray instance.

By default, the remote execution is postponed because UDTF calls can be composed. For example:

```python
In [17]: @omnisci('int32(Column<int64> x, OutputColumn<int64> y)')
    ...: def aincr(x, y):
    ...:     set_output_row_size(len(x))
    ...:     for i in range(len(x)):
    ...:         y[i] = x[i] + 1
    ...:     return len(y)
    ...: 

In [18]: print(aincr(arange(5)))
SELECT y FROM TABLE(aincr(CURSOR(SELECT x FROM TABLE(arange(CAST(5 AS INT))))))

In [19]: aincr(arange(5))['y']
Out[19]: array([1, 2, 3, 4, 5])

In [20]: aincr(aincr(arange(5)))['y']
Out[20]: array([2, 3, 4, 5, 6])
```

In the case of UDFs, the remote execution ~is immediate (unless one explicitly holds it back)~ is postponed as well:
```python
In [21]: @omnisci('int64(int64)')
    ...: def incr(x): return x + 1

In [22]: print(incr)
incr['int64(int64)']

In [23]: print(incr(5))
SELECT incr(CAST(5 AS BIGINT))

In [24]: incr(5).execute()
Out[24]: 6
```