### PR TITLE
ENH: add unregister of callers locally and on the server

### DIFF
--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -364,6 +364,14 @@ class RemoteOmnisci(RemoteJIT):
             m = re.match(r'.*Exception: (.*)', msg.error_msg)
             if m:
                 raise OmnisciServerError(f'{m.group(1)}')
+            m = re.match(
+                    r'(.*)\: No match found for function signature (.*)\(.*\)',
+                         msg.error_msg
+            )
+            if m:
+                msg = (f"Undefined function call {m.group(2)!r} in"
+                       f" SQL statement: {m.group(1)}")
+                raise OmnisciServerError(msg)
             m = re.match(r'.*SQL Error: (.*)', msg.error_msg)
             if m:
                 raise OmnisciServerError(f'{m.group(1)}')

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -1013,6 +1013,7 @@ class RemoteOmnisci(RemoteJIT):
             atypes, rtype)
 
     def register(self):
+        """Register caller cache to the server."""
         with typesystem.Type.alias(**self.typesystem_aliases):
             return self._register()
 
@@ -1127,6 +1128,11 @@ class RemoteOmnisci(RemoteJIT):
         return self.thrift_call(
             'register_runtime_extension_functions',
             self.session_id, udfs, udtfs, device_ir_map)
+
+    def unregister(self):
+        """Unregister caller cache locally and on the server."""
+        self.reset()
+        self.register()
 
     def preprocess_callable(self, func):
         func = super().preprocess_callable(func)

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -472,8 +472,8 @@ class RemoteOmnisci(RemoteJIT):
             if m:
                 raise OmnisciServerError(f'{m.group(1)}')
             m = re.match(
-                    r'(.*)\: No match found for function signature (.*)\(.*\)',
-                         msg.error_msg
+                r'(.*)\: No match found for function signature (.*)\(.*\)',
+                msg.error_msg
             )
             if m:
                 msg = (f"Undefined function call {m.group(2)!r} in"

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -201,7 +201,7 @@ def test_loadtime_udf(omnisci):
             'select i4, udf_diff2(i4, i4) from {omnisci.table_name}'
             .format(**locals()))
     except Exception as msg:
-        assert 'No match found for function signature udf_diff' in str(msg)
+        assert "Undefined function call 'udf_diff2'" in str(msg)
         return
     result = list(result)
     for i_, (i, d) in enumerate(result):

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -748,7 +748,7 @@ def test_unregistering(omnisci):
 
     omnisci.unregister()
 
-    msg = "No match found for function"
+    msg = "Undefined function call"
     with pytest.raises(OmnisciServerError, match=msg):
         omnisci.sql_execute('select farenheight2celcius(40)')
 

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -735,6 +735,7 @@ def test_truncate_issue(omnisci):
         .format(**locals()))
     assert list(result)[0] == (64,)
 
+
 def test_unregistering(omnisci):
     omnisci.reset()
 

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -740,17 +740,17 @@ def test_unregistering(omnisci):
     omnisci.reset()
 
     @omnisci('i32(i32)')
-    def farenheight2celcius(f):
+    def fahrenheit2celsius(f):
         return (f - 32) * 5 / 9
 
-    _, result = omnisci.sql_execute('select farenheight2celcius(40)')
+    _, result = omnisci.sql_execute('select fahrenheit2celsius(40)')
     assert list(result)[0] == (4,)
 
     omnisci.unregister()
 
     msg = "Undefined function call"
     with pytest.raises(OmnisciServerError, match=msg):
-        omnisci.sql_execute('select farenheight2celcius(40)')
+        omnisci.sql_execute('select fahrenheit2celsius(40)')
 
 
 def test_format_type(omnisci):

--- a/rbc/tests/test_omnisci_mlpack.py
+++ b/rbc/tests/test_omnisci_mlpack.py
@@ -25,7 +25,7 @@ def test_mlpack(omnisci, func):
     try:
         _, result = omnisci.sql_execute(query)
     except OmnisciServerError as msg:
-        m = re.match(r'.*No match found for function signature ' + func + r'[(]',
+        m = re.match(fr'.*Undefined function call {func!r}',
                      msg.args[0])
         if m is not None:
             pytest.skip(f'test requires omniscidb server with MLPACK support: {msg}')


### PR DESCRIPTION
Allow to clean the server from registered functions.

Also noted that when the function does not exist on the server, the message is not very clear to me:

```
rbc.errors.OmnisciServerError: From line 1, column 8 to line 1, column 32: No match found for function signature farenheight2celcius(<NUMERIC>)
```