### PR TITLE
Support HeavyDB

### DIFF
--- a/rbc/extension_functions.thrift
+++ b/rbc/extension_functions.thrift
@@ -51,6 +51,8 @@ enum TExtArgumentType {
   ColumnListBool,
   ColumnTextEncodingDict,
   ColumnListTextEncodingDict,
+  ColumnTimestamp,
+  Timestamp,
 }
 
 /* See QueryEngine/TableFunctions/TableFunctionsFactory.h for required

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -223,7 +223,7 @@ def get_client_config(**config):
 
     if 'dbname' not in config:
         version = get_heavydb_version(host=config['host'], port=config['port'])
-        if version[:2] >= (6, 0):
+        if version is not None and version[:2] >= (6, 0):
             if version[:3] == (6, 0, 0) and version_date(version) < 20220301:
                 # TODO: remove this if-block when heavydb 6.0 is released.
                 config['dbname'] = 'omnisci'

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -355,8 +355,14 @@ service Omnisci {
         multiplexed=False,
         thrift_content=thrift_content,
         socket_timeout=60000)
-    version = client(Omnisci=dict(get_version=()))['Omnisci']['get_version']
-    _cache[host, port] = version = parse_version(version)
+    try:
+        version = client(Omnisci=dict(get_version=()))['Omnisci']['get_version']
+    except Exception as msg:
+        print(f'failed to get heavydb version[host={host}, port={port}]: {msg}')
+        version = None
+    else:
+        version = parse_version(version)
+    _cache[host, port] = version
     return version
 
 

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -21,7 +21,7 @@ from .omnisci_backend import (
 from .targetinfo import TargetInfo
 from .irtools import compile_to_LLVM
 from .errors import ForbiddenNameError, OmnisciServerError
-from .utils import parse_version
+from .utils import parse_version, version_date
 from . import ctools
 from . import typesystem
 
@@ -224,7 +224,11 @@ def get_client_config(**config):
     if 'dbname' not in config:
         version = get_heavydb_version(host=config['host'], port=config['port'])
         if version[:2] >= (6, 0):
-            config['dbname'] = 'heavyai'
+            if version[:3] == (6, 0, 0) and version_date(version) < 20220301:
+                # TODO: remove this if-block when heavydb 6.0 is released.
+                config['dbname'] = 'omnisci'
+            else:
+                config['dbname'] = 'heavyai'
         else:
             config['dbname'] = 'omnisci'
 

--- a/rbc/omniscidb.py
+++ b/rbc/omniscidb.py
@@ -850,6 +850,8 @@ class RemoteHeavyDB(RemoteJIT):
             'ColumnList<double>': typemap['TExtArgumentType'].get('ColumnListDouble'),
             'ColumnList<TextEncodingDict>': typemap['TExtArgumentType'].get(
                 'ColumnListTextEncodingDict'),
+            'Timestamp': typemap['TExtArgumentType'].get('Timestamp'),
+            'Column<Timestamp>': typemap['TExtArgumentType'].get('ColumnTimestamp'),
         }
 
         if self.version[:2] < (5, 4):
@@ -869,6 +871,7 @@ class RemoteHeavyDB(RemoteJIT):
                 ('float64', 'double'),
                 ('TextEncodingDict', 'TextEncodingDict'),
                 ('OmnisciTextEncodingDictType<>', 'TextEncodingDict'),
+                ('TimeStamp', 'TimeStamp'),
         ]:
             ext_arguments_map['OmnisciArrayType<%s>' % ptr_type] \
                 = ext_arguments_map.get('Array<%s>' % T)

--- a/rbc/tests/test_omnisci.py
+++ b/rbc/tests/test_omnisci.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.skipif(not available_version, reason=reason)
 
 
 def test_get_client_config(tmpdir):
+    heavyai_brand = rbc_omnisci.get_heavyai_brand()
     d = tmpdir.mkdir("omnisci")
     fh = d.join("client.conf")
     fh.write("""
@@ -35,8 +36,8 @@ use_host_target: False
 """)
     conf_file = os.path.join(fh.dirname, fh.basename)
 
-    old_conf = os.environ.get('OMNISCI_CLIENT_CONF')
-    os.environ['OMNISCI_CLIENT_CONF'] = conf_file
+    old_conf = os.environ.get(f'{heavyai_brand.upper()}_CLIENT_CONF')
+    os.environ[f'{heavyai_brand.upper()}_CLIENT_CONF'] = conf_file
 
     try:
         conf = rbc_omnisci.get_client_config()
@@ -44,15 +45,15 @@ use_host_target: False
         assert conf['password'] == 'secret'
         assert conf['port'] == 1234
         assert conf['host'] == 'example.com'
-        assert conf['dbname'] == 'omnisci'
+        assert conf['dbname'] == heavyai_brand
         assert conf['debug'] == bool(0)
         conf = rbc_omnisci.get_client_config(dbname='test')
         assert conf['dbname'] == 'test'
     finally:
         if old_conf is None:
-            del os.environ['OMNISCI_CLIENT_CONF']
+            del os.environ[f'{heavyai_brand.upper()}_CLIENT_CONF']
         else:
-            os.environ['OMNISCI_CLIENT_CONF'] = old_conf
+            os.environ[f'{heavyai_brand.upper()}_CLIENT_CONF'] = old_conf
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
~To test rbc against HeavyDB (former OmnisciDB) server, define `HEAVYAI_BRAND` environment variable.~
~When `HEAVYAI_BRAND` is not defined or contains a value `omnisci` then rbc expects that OmniscDB 5.10.2 or older server is running.~

rbc detects HeavyDB brand using the server version information.