### PR TITLE
Restore heavydb cmd to run tests on GitHub Actions

### DIFF
--- a/.github/workflows/rbc_test.yml
+++ b/.github/workflows/rbc_test.yml
@@ -220,7 +220,7 @@ jobs:
           EXPECTED_NUMBA_VERSION: ${{ matrix.numba-version }}
           RBC_TESTS_FULL: TRUE
         run: |
-          mamba run -n rbc pytest -sv -r A rbc/tests/heavydb/ -x
+          mamba run -n rbc pytest -sv -r A rbc/tests/ -x -k heavydb
 
       - name: Run rbc tests
         shell: bash -l {0}
@@ -231,7 +231,7 @@ jobs:
           EXPECTED_NUMBA_VERSION: ${{ matrix.numba-version }}
           RBC_TESTS_FULL: TRUE
         run: |
-          mamba run -n rbc pytest -sv -r A rbc/tests/heavydb/ -x
+          mamba run -n rbc pytest -sv -r A rbc/tests/ -x -k heavydb
 
       - name: Show Heavydb conda logs on failure [conda]
         shell: bash -l {0}

--- a/.github/workflows/rbc_test.yml
+++ b/.github/workflows/rbc_test.yml
@@ -31,70 +31,6 @@ jobs:
         run: |
           flake8 .
 
-  remotejit:
-    name: ${{ matrix.os }} - Python v${{ matrix.python-version }} - Numba v${{ matrix.numba-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # setting fail-fast=true seems to cause connection issues in remotejit tests
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.8', '3.7']
-        numba-version: ['0.55', '0.54']
-        include:
-          - os: ubuntu-latest
-            python-version: '3.10'
-            numba-version: '0.55'
-
-    needs: [lint, heavydb]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
-
-      - name: Configure miniconda
-        shell: bash -l {0}
-        run: |
-          conda env config vars set MAMBA_NO_BANNER=1
-      - name: Create rbc test environment v${{ matrix.python-version }}
-        shell: bash -l {0}
-        run: |
-          cat .conda/environment.yml > rbc_test.yaml
-          echo "  - numba=${{ matrix.numba-version }}" >> rbc_test.yaml
-          echo "  - python=${{ matrix.python-version }}" >> rbc_test.yaml
-          mamba env create  --file=rbc_test.yaml -n rbc
-      - name: rbc conda config
-        shell: bash -l {0}
-        run: mamba run -n rbc conda config --show
-
-      - name: rbc conda list
-        shell: bash -l {0}
-        run: |
-          mamba run -n rbc conda list
-
-      - name: Develop rbc
-        shell: bash -l {0}
-        run: |
-          mamba run -n rbc python setup.py develop
-      - name: Run rbc tests
-        shell: bash -l {0}
-        env:
-          EXPECTED_PYTHON_VERSION: ${{ matrix.python-version }}
-          EXPECTED_NUMBA_VERSION: ${{ matrix.numba-version }}
-        run: |
-          mamba run -n rbc pytest -sv -r A rbc/ -x
-
   heavydb:
     name: Heavydb ${{ matrix.heavydb-version }} - ${{ matrix.os }} - Numba v${{matrix.numba-version}} - Python v${{ matrix.python-version }} [${{ matrix.heavydb-from }}]
     runs-on: ${{ matrix.os }}
@@ -221,6 +157,7 @@ jobs:
           RBC_TESTS_FULL: TRUE
         run: |
           mamba run -n rbc pytest -sv -r A rbc/tests/ -x -k heavydb
+          mamba run -n rbc pytest -sv -r A rbc/tests/ -x -k "not heavydb"
 
       - name: Run rbc tests
         shell: bash -l {0}
@@ -232,6 +169,7 @@ jobs:
           RBC_TESTS_FULL: TRUE
         run: |
           mamba run -n rbc pytest -sv -r A rbc/tests/ -x -k heavydb
+          mamba run -n rbc pytest -sv -r A rbc/tests/ -x -k "not heavydb"
 
       - name: Show Heavydb conda logs on failure [conda]
         shell: bash -l {0}


### PR DESCRIPTION
* Restore the command to run heavydb tests. There are a few tests that requires heavydb that are not on `rbc/tests/heavydb/`
* Remove the `remotejit` section and run its tests after the heavydb ones. This should speed up the test suite execution by avoiding setting up new containers and creating the conda environment just to run non-heavydb tests.