### PR TITLE
Remove pytest.mark.skip from test

### DIFF
--- a/rbc/tests/heavydb/test_array_api_unsupported.py
+++ b/rbc/tests/heavydb/test_array_api_unsupported.py
@@ -37,7 +37,6 @@ unsupported_functions = [
 
 # ensure unimplemented functions raise a meaninful exception
 @pytest.mark.parametrize('func_name', unsupported_functions)
-@pytest.mark.skip()
 def test_unimplemented(heavydb, func_name):
 
     func = getattr(array_api, func_name)


### PR DESCRIPTION
This restores a set of tests that were previously marked to be skipped