### PR TITLE
Fix an error in return buffer values on UDF

### DIFF
--- a/rbc/heavydb/array.py
+++ b/rbc/heavydb/array.py
@@ -40,7 +40,7 @@ class HeavyDBArrayType(HeavyDBBufferType):
 
 
 class ArrayPointer(BufferPointer):
-    def copy(self, context, builder, val, retptr):
+    def deepcopy(self, context, builder, val, retptr):
         from .buffer import memalloc
         ptr_type = self.dtype.members[0]
         element_size = int64_t(ptr_type.dtype.bitwidth // 8)

--- a/rbc/heavydb/array.py
+++ b/rbc/heavydb/array.py
@@ -45,9 +45,10 @@ class ArrayPointer(BufferPointer):
         ptr_type = self.dtype.members[0]
         element_size = int64_t(ptr_type.dtype.bitwidth // 8)
 
-        src = builder.extract_value(builder.load(val), 0)
-        element_count = builder.extract_value(builder.load(val), 1)
-        is_null = builder.extract_value(builder.load(val), 2)
+        struct_load = builder.load(val, name='struct_load')
+        src = builder.extract_value(struct_load, 0, name='array_buff_ptr')
+        element_count = builder.extract_value(struct_load, 1, name='array_size')
+        is_null = builder.extract_value(struct_load, 2, name='array_is_null')
 
         zero, one, two = int32_t(0), int32_t(1), int32_t(2)
         with builder.if_else(cgutils.is_true(builder, is_null)) as (then, otherwise):

--- a/rbc/heavydb/buffer.py
+++ b/rbc/heavydb/buffer.py
@@ -125,7 +125,7 @@ class BufferPointer(types.IterableType):
     def iterator_type(self):
         return BufferIteratorType(self)
 
-    def copy(self, context, builder, val, retptr):
+    def deepcopy(self, context, builder, val, retptr):
         raise NotImplementedError
 
 

--- a/rbc/heavydb/text_encoding_none.py
+++ b/rbc/heavydb/text_encoding_none.py
@@ -132,7 +132,7 @@ def text_encoding_none_ne(a, b):
     if isinstance(a, TextEncodingNonePointer):
         if isinstance(b, (TextEncodingNonePointer, nb_types.StringLiteral)):
             def impl(a, b):
-                return not(a == b)
+                return not (a == b)
             return impl
 
 

--- a/rbc/heavydb/text_encoding_none.py
+++ b/rbc/heavydb/text_encoding_none.py
@@ -54,9 +54,10 @@ class TextEncodingNonePointer(ArrayPointer):
         ptr_type = self.dtype.members[0]
         element_size = int64_t(ptr_type.dtype.bitwidth // 8)
 
-        src = builder.extract_value(builder.load(val), 0)
-        element_count = builder.extract_value(builder.load(val), 1)
-        is_null = builder.extract_value(builder.load(val), 2)
+        struct_load = builder.load(val)
+        src = builder.extract_value(struct_load, 0, name='text_buff_ptr')
+        element_count = builder.extract_value(struct_load, 1, name='text_size')
+        is_null = builder.extract_value(struct_load, 2, name='text_is_null')
 
         zero, one, two = int32_t(0), int32_t(1), int32_t(2)
         ptr = memalloc(context, builder, ptr_type, element_count, element_size)

--- a/rbc/heavydb/text_encoding_none.py
+++ b/rbc/heavydb/text_encoding_none.py
@@ -49,7 +49,7 @@ class HeavyDBTextEncodingNoneType(HeavyDBBufferType):
 
 
 class TextEncodingNonePointer(ArrayPointer):
-    def copy(self, context, builder, val, retptr):
+    def deepcopy(self, context, builder, val, retptr):
         from .buffer import memalloc
         ptr_type = self.dtype.members[0]
         element_size = int64_t(ptr_type.dtype.bitwidth // 8)
@@ -76,8 +76,8 @@ class TextEncodingNone(Buffer):
 
         struct TextEncodingNone {
             char* ptr;
-            size_t sz;  // when non-negative, TextEncodingNone has fixed width.
-            int8_t is_null;
+            size_t size;
+            int8_t padding;
         }
 
     .. code-block:: python

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -246,7 +246,7 @@ def make_wrapper(fname, atypes, rtype, cres, target: TargetInfo, verbose=False):
                 stdio._cg_fflush(builder)
             builder.ret_void()
         # does a "deepcopy"
-        rtype.copy(context, builder, out, wrapfn.args[0])
+        rtype.deepcopy(context, builder, out, wrapfn.args[0])
         builder.ret_void()
     else:
         wrapty = ir.FunctionType(ll_return_type, ll_argtypes)

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -245,7 +245,8 @@ def make_wrapper(fname, atypes, rtype, cres, target: TargetInfo, verbose=False):
                                status.code)
                 stdio._cg_fflush(builder)
             builder.ret_void()
-        builder.store(builder.load(out), wrapfn.args[0])
+        # does a "deepcopy"
+        rtype.copy(context, builder, out, wrapfn.args[0])
         builder.ret_void()
     else:
         wrapty = ir.FunctionType(ll_return_type, ll_argtypes)

--- a/rbc/tests/heavydb/test_array.py
+++ b/rbc/tests/heavydb/test_array.py
@@ -544,5 +544,5 @@ def test_return_array(heavydb):
     heavydb.register()
     _, result = heavydb.sql_execute(f'select i8, fn(i8) from {heavydb.table_name};')
     result = list(zip(*result))
-    expected, got = zip(*result)
+    expected, got = result
     assert expected == got

--- a/rbc/tests/heavydb/test_array.py
+++ b/rbc/tests/heavydb/test_array.py
@@ -544,4 +544,5 @@ def test_return_array(heavydb):
     heavydb.register()
     _, result = heavydb.sql_execute(f'select i8, fn(i8) from {heavydb.table_name};')
     result = list(zip(*result))
-    np.testing.assert_equal(*result)
+    expected, got = zip(*result)
+    assert expected == got

--- a/rbc/tests/heavydb/test_array.py
+++ b/rbc/tests/heavydb/test_array.py
@@ -533,3 +533,15 @@ def test_array_ndim(heavydb):
 
     _, result = heavydb.sql_execute(f'select get_ndim(f4) from {heavydb.table_name} limit 1;')
     assert list(result) == [(1,)]
+
+
+def test_return_array(heavydb):
+
+    @heavydb('int64[](int64[])', devices=['cpu'])
+    def fn(a):
+        return a
+
+    heavydb.register()
+    _, result = heavydb.sql_execute(f'select i8, fn(i8) from {heavydb.table_name};')
+    result = list(zip(*result))
+    np.testing.assert_equal(*result)

--- a/rbc/tests/heavydb/test_math.py
+++ b/rbc/tests/heavydb/test_math.py
@@ -197,7 +197,7 @@ def test_math_function(heavydb, device, nb_version, fn_name, signature):
         if np.isnan(expected):
             assert np.isnan(result)
         else:
-            assert(np.isclose(expected, result))
+            assert np.isclose(expected, result)
 
 
 numpy_functions = [
@@ -385,4 +385,4 @@ def test_numpy_function(heavydb, device, nb_version, fn_name, signature, np_func
         if np.isnan(expected):
             assert np.isnan(result), fn_name
         else:
-            assert(np.isclose(expected, result)), fn_name
+            assert np.isclose(expected, result), fn_name

--- a/rbc/tests/heavydb/test_text_encoding_none.py
+++ b/rbc/tests/heavydb/test_text_encoding_none.py
@@ -1,4 +1,3 @@
-import numpy as np
 from rbc.tests import heavydb_fixture
 from rbc.heavydb import TextEncodingNone
 import pytest
@@ -180,8 +179,8 @@ def test_return_text(heavydb):
     def fn(t):
         return t
 
-    col = 'n'
     table = heavydb.table_name + 'text'
-    _, result = heavydb.sql_execute(f"select {col}, fn({col}) from {table};")
+    _, result = heavydb.sql_execute(f"select n, fn(n) from {table};")
     result = list(zip(*result))
-    np.testing.assert_equal(*result)
+    expected, got = zip(*result)
+    assert expected == got

--- a/rbc/tests/heavydb/test_text_encoding_none.py
+++ b/rbc/tests/heavydb/test_text_encoding_none.py
@@ -182,5 +182,5 @@ def test_return_text(heavydb):
     table = heavydb.table_name + 'text'
     _, result = heavydb.sql_execute(f"select n, fn(n) from {table};")
     result = list(zip(*result))
-    expected, got = zip(*result)
+    expected, got = result
     assert expected == got

--- a/rbc/tests/heavydb/test_text_encoding_none.py
+++ b/rbc/tests/heavydb/test_text_encoding_none.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rbc.tests import heavydb_fixture
 from rbc.heavydb import TextEncodingNone
 import pytest
@@ -172,3 +173,15 @@ def test_if_else_assignment(heavydb):
     assert classify_slope(2.4).execute() == "low"
     assert classify_slope(5.4).execute() == "med"
     assert classify_slope(15.4).execute() == "high"
+
+
+def test_return_text(heavydb):
+    @heavydb("TextEncodingNone(TextEncodingNone)", devices=['cpu'])
+    def fn(t):
+        return t
+
+    col = 'n'
+    table = heavydb.table_name + 'text'
+    _, result = heavydb.sql_execute(f"select {col}, fn({col}) from {table};")
+    result = list(zip(*result))
+    np.testing.assert_equal(*result)

--- a/rbc/tests/heavydb/test_udtf.py
+++ b/rbc/tests/heavydb/test_udtf.py
@@ -157,7 +157,7 @@ def test_table_function_manager(heavydb):
         f'cursor(select f8 from {heavydb.table_name})));')
 
     expected = [(0.0,), (1.0,), (2.0,), (3.0,), (4.0,)]
-    assert(list(result) == expected)
+    assert list(result) == expected
 
 
 @pytest.mark.parametrize("sleep", ['ct_sleep1', 'ct_sleep2'])

--- a/rbc/tests/test_numpy_rjit.py
+++ b/rbc/tests/test_numpy_rjit.py
@@ -56,7 +56,7 @@ def test_logaddexp(rjit):
                 logxf = np.log(np.array(_x, dtype=dt))
                 logyf = np.log(np.array(_y, dtype=dt))
                 logzf = np.log(np.array(_z, dtype=dt))
-                assert(np.allclose(logaddexp(logxf, logyf), logzf))
+                assert np.allclose(logaddexp(logxf, logyf), logzf)
 
     def test_range():
         x = [1000000, -1000000, 1000200, -1000200]
@@ -68,7 +68,7 @@ def test_logaddexp(rjit):
                 xf = np.array(_x, dtype=dt)[()]
                 yf = np.array(_y, dtype=dt)[()]
                 zf = np.array(_z, dtype=dt)[()]
-                assert(np.allclose(logaddexp(xf, yf), zf))
+                assert np.allclose(logaddexp(xf, yf), zf)
 
     def test_inf():
         # logaddexp inf
@@ -83,14 +83,14 @@ def test_logaddexp(rjit):
                     xf = np.array(_x, dtype=dt)[()]
                     yf = np.array(_y, dtype=dt)[()]
                     zf = np.array(_z, dtype=dt)[()]
-                    assert(np.allclose(logaddexp(xf, yf), zf))
+                    assert np.allclose(logaddexp(xf, yf), zf)
 
     def test_nan():
-        assert(np.isnan(logaddexp(np.nan, np.inf)))
-        assert(np.isnan(logaddexp(np.inf, np.nan)))
-        assert(np.isnan(logaddexp(np.nan, 0)))
-        assert(np.isnan(logaddexp(0, np.nan)))
-        assert(np.isnan(logaddexp(np.nan, np.nan)))
+        assert np.isnan(logaddexp(np.nan, np.inf))
+        assert np.isnan(logaddexp(np.inf, np.nan))
+        assert np.isnan(logaddexp(np.nan, 0))
+        assert np.isnan(logaddexp(0, np.nan))
+        assert np.isnan(logaddexp(np.nan, np.nan))
 
     test_values()
     test_range()
@@ -114,7 +114,7 @@ def test_logaddexp2(rjit):
                 logxf = np.log2(np.array(_x, dtype=dt))
                 logyf = np.log2(np.array(_y, dtype=dt))
                 logzf = np.log2(np.array(_z, dtype=dt))
-                assert(np.allclose(logaddexp2(logxf, logyf), logzf))
+                assert np.allclose(logaddexp2(logxf, logyf), logzf)
 
     def test_range():
         x = [1000000, -1000000, 1000200, -1000200]
@@ -126,7 +126,7 @@ def test_logaddexp2(rjit):
                 xf = np.array(_x, dtype=dt)[()]
                 yf = np.array(_y, dtype=dt)[()]
                 zf = np.array(_z, dtype=dt)[()]
-                assert(np.allclose(logaddexp2(xf, yf), zf))
+                assert np.allclose(logaddexp2(xf, yf), zf)
 
     def test_inf():
         # logaddexp2 inf
@@ -141,14 +141,14 @@ def test_logaddexp2(rjit):
                     xf = np.array(_x, dtype=dt)[()]
                     yf = np.array(_y, dtype=dt)[()]
                     zf = np.array(_z, dtype=dt)[()]
-                    assert(np.allclose(logaddexp2(xf, yf), zf))
+                    assert np.allclose(logaddexp2(xf, yf), zf)
 
     def test_nan():
-        assert(np.isnan(logaddexp2(np.nan, np.inf)))
-        assert(np.isnan(logaddexp2(np.inf, np.nan)))
-        assert(np.isnan(logaddexp2(np.nan, 0)))
-        assert(np.isnan(logaddexp2(0, np.nan)))
-        assert(np.isnan(logaddexp2(np.nan, np.nan)))
+        assert np.isnan(logaddexp2(np.nan, np.inf))
+        assert np.isnan(logaddexp2(np.inf, np.nan))
+        assert np.isnan(logaddexp2(np.nan, 0))
+        assert np.isnan(logaddexp2(0, np.nan))
+        assert np.isnan(logaddexp2(np.nan, np.nan))
 
     test_values()
     test_range()


### PR DESCRIPTION
Currently, RBC uses the Numba calling convention and bet that LLVM can optmize the code to the point the result IR conforms to the HeavyDB calling convention. This pull request is the first patch to fix this, so we don't end up with unwanted `unreachable()` instructions.

### Calling convention

Given the function `fn` declared below which returns a copy of the input array. Numba will generate an LLVM IR which stores the input array pointer into the return pointer.

```python
def fn(a: Array) -> Array:
    ret = a
    return ret
```

```llvm
define i32 @fn__iner_cpu_0({ i64*, i64, i8 }** noalias nocapture %retptr, { i8*, i32, i8* }** noalias nocapture %excinfo, { i64*, i64, i8 }* %arg.a) {
entry:
  br label %B0

B0:                                               ; preds = %entry
  store { i64*, i64, i8 }* %arg.a, { i64*, i64, i8 }** %retptr, align 8
  ret i32 0
}
```

By the Numba calling convention

1) Return type is passed as the first argument to the function (`%retptr`)
2) Second argument is a pointer to an exception info struct. Basically, it holds if the function raised an exception or not. Since we don't support exceptions, this struct is not used and deleted by DCE.
3) Third argument is a pointer to the input array.


RBC also generates a wrapper function that conforms with the HeavyDB calling convention:

* If the UDF returns a scalar, its signature is `udf(arg1, ..., argN) -> scalar`
* If its a struct, then the signature is `udf(retptr*, arg1, ..., argN) -> void`

The problem with the wrapper we generate is that we only copy the return pointer from the inner function, whereas it should be deep copied.

```llvm
define void @"fn__wrapper_cpu_0"({i64*, i64, i8}* %".1", {i64*, i64, i8}* %".2"){
entry:
  %.4 = alloca { i64*, i64, i8 }*, align 8
  store { i64*, i64, i8 }* null, { i64*, i64, i8 }** %.4, align 8
  %excinfo = alloca { i8*, i32, i8* }*, align 8
  store { i8*, i32, i8* }* null, { i8*, i32, i8* }** %excinfo, align 8
  %.8 = call i32 @fn__inner_cpu_0({ i64*, i64, i8 }** %.4, { i8*, i32, i8* }** %excinfo, i64 %.2)
  %.9 = load { i8*, i32, i8* }*, { i8*, i32, i8* }** %excinfo, align 8
  %.10 = icmp eq i32 %.8, 0
  %.11 = icmp eq i32 %.8, -2
  %.14 = or i1 %.10, %.11
  %.15 = xor i1 %.14, true
  %.16 = icmp sge i32 %.8, 1
  %.18 = load { i64*, i64, i8 }*, { i64*, i64, i8 }** %.4, align 8
  br i1 %.15, label %entry.if, label %entry.endif, !prof !0

entry.if:                                         ; preds = %entry
  ret void

entry.endif:                                      ; preds = %entry
  %.21 = load { i64*, i64, i8 }, { i64*, i64, i8 }* %.18, align 8
  ; copies the return pointer from inner into the retptr (%.1)
  store { i64*, i64, i8 } %.21, { i64*, i64, i8 }* %.1, align 8
  ret void
}
```

This PR introduces a new method that Buffer subclasses can overload. This method is responsible for generating LLVM code that copies each buffer element into the return pointer.