### PR TITLE
Support `Column<Array<T>>`

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -58,7 +58,6 @@ Externals
     externals.heavydb
     externals.stdio
 
-
 HeavyDB Backend
 ===============
 
@@ -75,9 +74,14 @@ one cannot create and use them inside the REPL, for instance.
 
     heavydb.Array
     heavydb.Column
+    heavydb.ColumnArray
+    heavydb.ColumnListArray
     heavydb.ColumnList
     heavydb.TextEncodingDict
     heavydb.TextEncodingNone
     heavydb.Timestamp
     heavydb.DayTimeInterval
     heavydb.YearMonthTimeInterval
+    heavydb.TableFunctionManager
+    heavydb.RowFunctionManager
+    heavydb.StringDictionaryProxy

--- a/rbc/heavydb/__init__.py
+++ b/rbc/heavydb/__init__.py
@@ -1,9 +1,11 @@
 from .array import *  # noqa: F401, F403
 from .column import *  # noqa: F401, F403
+from .column_array import *  # noqa: F401, F403
 from .buffer import *  # noqa: F401, F403
 from .metatype import *  # noqa: F401, F403
 from .pipeline import *  # noqa: F401, F403
 from .column_list import *  # noqa: F401, F403
+from .column_list_array import *  # noqa: F401, F403
 from .table_function_manager import *  # noqa: F401, F403
 from .row_function_manager import *  # noqa: F401, F403
 from .text_encoding_dict import *  # noqa: F401, F403

--- a/rbc/heavydb/abstract_type.py
+++ b/rbc/heavydb/abstract_type.py
@@ -1,0 +1,44 @@
+
+__all__ = ['HeavyDBAbstractType']
+
+from abc import abstractmethod
+from rbc import typesystem
+
+
+class HeavyDBAbstractType(typesystem.Type):
+    """The type where all HeavyDB types must inherit from
+    """
+
+    @property
+    @abstractmethod
+    def pass_by_value(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def numba_type(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def numba_pointer_type(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def element_type(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def buffer_extra_members(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def custom_params(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def tonumba(self, bool_is_int8=None):
+        raise NotImplementedError

--- a/rbc/heavydb/buffer.py
+++ b/rbc/heavydb/buffer.py
@@ -25,6 +25,7 @@ HeavyDB buffer objects from UDF/UDTFs.
 
 import operator
 from .metatype import HeavyDBMetaType
+from .abstract_type import HeavyDBAbstractType
 from llvmlite import ir
 import numpy as np
 from rbc import typesystem
@@ -39,7 +40,7 @@ fp32 = ir.FloatType()
 fp64 = ir.DoubleType()
 
 
-class HeavyDBBufferType(typesystem.Type):
+class HeavyDBBufferType(HeavyDBAbstractType):
     """Typesystem type class for HeavyDB buffer structures.
     """
     # When True, buffer type arguments are passed by value to

--- a/rbc/heavydb/buffer.py
+++ b/rbc/heavydb/buffer.py
@@ -73,6 +73,13 @@ class HeavyDBBufferType(typesystem.Type):
     def buffer_extra_members(self):
         return ()
 
+    @property
+    def custom_params(self):
+        return {
+            'NumbaType': self.numba_type,
+            'NumbaPointerType': self.numba_pointer_type,
+        }
+
     def tonumba(self, bool_is_int8=None):
         ptr_t = typesystem.Type(self.element_type, '*', name='ptr')
         size_t = typesystem.Type.fromstring('size_t sz')
@@ -82,8 +89,7 @@ class HeavyDBBufferType(typesystem.Type):
             size_t,
             *extra_members
         )
-        buffer_type._params['NumbaType'] = self.numba_type
-        buffer_type._params['NumbaPointerType'] = self.numba_pointer_type
+        buffer_type.params(other=None, **self.custom_params)
         numba_type = buffer_type.tonumba(bool_is_int8=True)
         if self.pass_by_value:
             return numba_type

--- a/rbc/heavydb/column.py
+++ b/rbc/heavydb/column.py
@@ -26,11 +26,12 @@ class HeavyDBColumnType(HeavyDBBufferType):
     """
 
     def postprocess_type(self):
-        # importing here to avoid circular import issue
-        from .array import HeavyDBArrayType
-        if isinstance(self[0][0], HeavyDBArrayType):
+        if self.tostring().startswith('HeavyDBColumnType<HeavyDBArrayType'):
             from .column_array import HeavyDBColumnArrayType
             return self.copy(cls=HeavyDBColumnArrayType)
+        elif self.tostring().startswith('HeavyDBOutputColumnType<HeavyDBArrayType'):
+            from .column_array import HeavyDBOutputColumnArrayType
+            return self.copy(cls=HeavyDBOutputColumnArrayType)
         return self
 
     @property

--- a/rbc/heavydb/column.py
+++ b/rbc/heavydb/column.py
@@ -11,6 +11,7 @@ from llvmlite import ir
 from rbc import typesystem
 from .buffer import Buffer, HeavyDBBufferType, BufferType, BufferPointer
 from .column_list import HeavyDBColumnListType
+from . import text_encoding_none
 from rbc.targetinfo import TargetInfo
 from numba.core import extending, cgutils
 from numba.core import types as nb_types
@@ -79,7 +80,7 @@ class Column(Buffer):
         Data type of the array elements.
         """
 
-    def getStringId(self, s: Union[str, 'TextEncodingNone']) -> int:  # noqa: F821
+    def getStringId(self, s: Union[str, 'text_encoding_none.TextEncodingNone']) -> int:  # noqa: F821
         """
         Return the string ID for the given string ``s``.
 

--- a/rbc/heavydb/column.py
+++ b/rbc/heavydb/column.py
@@ -80,7 +80,7 @@ class Column(Buffer):
         Data type of the array elements.
         """
 
-    def getStringId(self, s: Union[str, 'text_encoding_none.TextEncodingNone']) -> int:  # noqa: F821
+    def getStringId(self, s: Union[str, 'text_encoding_none.TextEncodingNone']) -> int:  # noqa: E501
         """
         Return the string ID for the given string ``s``.
 

--- a/rbc/heavydb/column.py
+++ b/rbc/heavydb/column.py
@@ -24,6 +24,15 @@ int32_t = ir.IntType(32)
 class HeavyDBColumnType(HeavyDBBufferType):
     """Heavydb Column type for RBC typesystem.
     """
+
+    def postprocess_type(self):
+        # importing here to avoid circular import issue
+        from .array import HeavyDBArrayType
+        if isinstance(self[0][0], HeavyDBArrayType):
+            from .column_array import HeavyDBColumnArrayType
+            return self.copy(cls=HeavyDBColumnArrayType)
+        return self
+
     @property
     def pass_by_value(self):
         heavydb_version = TargetInfo().software[1][:3]

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -5,15 +5,26 @@ Heavydb Column<Array<T>> type is the type of input/output column arguments in
 UDTFs.
 """
 
-# __all__ = ['OutputColumn', 'Column', 'HeavyDBOutputColumnType', 'HeavyDBColumnType',
-#            'HeavyDBCursorType']
+__all__ = ['HeavyDBOutputColumnArrayType', 'HeavyDBColumnArrayType']
 
 import operator
 from rbc import typesystem
 from .column import HeavyDBColumnType
-from .buffer import BufferType, BufferPointer
-from numba.core import extending
+from numba.core import extending, cgutils
 from numba.core import types as nb_types
+from llvmlite import ir
+
+
+i1 = ir.IntType(1)
+i8 = ir.IntType(8)
+i8p = i8.as_pointer()
+i8pp = i8p.as_pointer()
+i64 = ir.IntType(64)
+i64p = i64.as_pointer()
+void = ir.VoidType()
+
+
+_COLUMN_PARAM_NAME = 'ColumnArray_inner_type'
 
 
 class HeavyDBColumnArrayType(HeavyDBColumnType):
@@ -33,30 +44,45 @@ class HeavyDBColumnArrayType(HeavyDBColumnType):
     def element_type(self):
         return typesystem.Type.fromstring('int8_t')
 
+    @property
+    def custom_params(self):
+        return {
+            **super().custom_params,
+            _COLUMN_PARAM_NAME: self[0][0]
+        }
+
+
+class HeavyDBOutputColumnArrayType(HeavyDBColumnArrayType):
+    """Heavydb OutputColumn type for RBC typesystem.
+
+    OutputColumn is the same as Column<Array<T>> but introduced to distinguish
+    the input and output arguments of UDTFs.
+    """
+
 
 class ColumnArrayType(nb_types.Type):
     """Numba type class for HeavyDB buffer structures.
     """
 
     def __init__(self, dtype):
-        breakpoint()
+        array_T = self.__typesystem_type__._params.get(_COLUMN_PARAM_NAME)
+        eltype = array_T.tonumba().eltype
+        self.dtype = array_T.tonumba()  # struct dtype
+        name = f"Column<Array<{eltype}>>"
+        super().__init__(name)
 
     @property
     def eltype(self):
         """
         Return buffer element dtype.
         """
-        return self.members[0].dtype
-
-    # @property
-    # def iterator_type(self):
-    #     return BufferIteratorType(self)
+        return self.dtype.eltype
 
 
 class ColumnArrayPointer(nb_types.Type):
     """Numba type class for pointers to HeavyDB buffer structures.
 
-    We are not deriving from CPointer because BufferPointer getitem is
+    We are not deriving from CPointer because ColumnArrayPointer getitem is
     used to access the data stored in Buffer ptr member.
     """
     mutable = True
@@ -73,7 +99,195 @@ class ColumnArrayPointer(nb_types.Type):
         return self.dtype
 
 
+@extending.intrinsic
+def heavydb_column_array_getitem_(typingctx, x, i):
+    T = x.eltype
+    array = typesystem.Type.fromstring(f'Array<{T}>').tonumba().dtype
+    sig = array(x, i)
+
+    def codegen(context, builder, sig, args):
+        col, index = args
+        fa = cgutils.create_struct_proxy(sig.return_type)(context, builder)
+        fnty = ir.FunctionType(void, [i8p, i64, i64, i8pp, i64p, i8p, i64])
+        getItem = cgutils.get_or_insert_function(builder.module, fnty,
+                                                 "ColumnArray_getItem")
+        flatbuffer = builder.extract_value(col, [0])
+        ptr = builder.alloca(fa.ptr.type)
+        size = builder.alloca(fa.sz.type)
+        is_null = builder.alloca(fa.is_null.type)
+        expected_numel = i64(-1)
+        element_size = i64(array.eltype.bitwidth // 8)
+        builder.call(getItem, [flatbuffer, index, expected_numel,
+                               builder.bitcast(ptr, i8pp), size,
+                               is_null, element_size])
+        fa.ptr = builder.load(ptr)
+        fa.sz = builder.sdiv(builder.load(size), element_size)
+        fa.is_null = builder.load(is_null)
+        return fa._getvalue()
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_array_setitem_(typingctx, x, i, arr):
+    sig = nb_types.void(x, i, arr)
+
+    def codegen(context, builder, sig, args):
+        col, index, arr_ = args
+        fnty = ir.FunctionType(void, [i8p, i64, i8p, i64, i8, i64])
+        getItem = cgutils.get_or_insert_function(builder.module, fnty,
+                                                 "ColumnArray_setItem")
+        flatbuffer = builder.extract_value(col, [0])
+        element_size = i64(arr.eltype.bitwidth // 8)
+        fa = cgutils.create_struct_proxy(arr)(context, builder, value=arr_)
+        builder.call(getItem, [flatbuffer, index, builder.bitcast(fa.ptr, i8p),
+                               fa.sz, fa.is_null, element_size])
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_array_concatitem_(typingctx, x, i, arr):
+    sig = nb_types.void(x, i, arr)
+
+    def codegen(context, builder, sig, args):
+        col, index, arr_ = args
+        fnty = ir.FunctionType(void, [i8p, i64, i8p, i64, i8, i64])
+        getItem = cgutils.get_or_insert_function(builder.module, fnty,
+                                                 "ColumnArray_concatItem")
+        flatbuffer = builder.extract_value(col, [0])
+        element_size = i64(arr.eltype.bitwidth // 8)
+        fa = cgutils.create_struct_proxy(arr)(context, builder, value=arr_)
+        builder.call(getItem, [flatbuffer, index, builder.bitcast(fa.ptr, i8p),
+                               fa.sz, fa.is_null, element_size])
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_array_is_null_(typingctx, x, i):
+    sig = nb_types.boolean(x, i)
+
+    def codegen(context, builder, sig, args):
+        col, index = args
+        fnty = ir.FunctionType(i1, [i8p, i64])
+        isNull = cgutils.get_or_insert_function(builder.module, fnty,
+                                                "ColumnArray_isNull")
+        flatbuffer = builder.extract_value(col, [0])
+        return builder.call(isNull, [flatbuffer, index])
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_array_set_null_(typingctx, x, i):
+    sig = nb_types.void(x, i)
+
+    def codegen(context, builder, sig, args):
+        col, index = args
+        fnty = ir.FunctionType(i1, [i8p, i64])
+        setNull = cgutils.get_or_insert_function(builder.module, fnty,
+                                                 "ColumnArray_setNull")
+        flatbuffer = builder.extract_value(col, [0])
+        builder.call(setNull, [flatbuffer, index])
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def deref(typingctx, x):
+    sig = x.dtype(x)
+
+    def codegen(context, builder, sig, args):
+        [ptr] = args
+        return builder.load(ptr)
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_array_len_(typingctx, x):
+    sig = nb_types.int64(x)
+
+    def codegen(context, builder, sig, args):
+        [col] = args
+        return builder.extract_value(col, [1])
+
+    return sig, codegen
+
+
 @extending.overload(operator.getitem)
-def heavydb_buffer_getitem(x, i):
+def heavydb_column_array_getitem(x, i):
     if isinstance(x, ColumnArrayPointer):
-        breakpoint()
+        def impl(x, i):
+            return heavydb_column_array_getitem_(deref(x), i)
+        return impl
+    elif isinstance(x, ColumnArrayType):
+        def impl(x, i):
+            return heavydb_column_array_getitem_(x, i)
+        return impl
+
+
+@extending.overload_method(ColumnArrayPointer, 'is_null')
+def heavydb_column_array_ptr_is_null(x, i):
+    def impl(x, i):
+        return heavydb_column_array_is_null_(deref(x), i)
+    return impl
+
+
+@extending.overload_method(ColumnArrayPointer, 'set_null')
+def heavydb_column_array_ptr_set_null(x, i):
+    def impl(x, i):
+        return heavydb_column_array_set_null_(deref(x), i)
+    return impl
+
+
+@extending.overload_method(ColumnArrayType, 'is_null')
+def heavydb_column_array_is_null(x, i):
+    def impl(x, i):
+        return heavydb_column_array_is_null_(x, i)
+    return impl
+
+
+@extending.overload_method(ColumnArrayType, 'set_null')
+def heavydb_column_array_set_null(x, i):
+    def impl(x, i):
+        return heavydb_column_array_set_null_(x, i)
+    return impl
+
+
+@extending.overload(operator.setitem)
+@extending.overload_method(ColumnArrayPointer, 'set_item')
+def heavydb_column_array_set_item(x, i, arr):
+    if isinstance(x, ColumnArrayPointer):
+        def impl(x, i, arr):
+            return heavydb_column_array_setitem_(deref(x), i, arr)
+        return impl
+    elif isinstance(x, ColumnArrayType):
+        def impl(x, i, arr):
+            return heavydb_column_array_setitem_(x, i, arr)
+        return impl
+
+
+@extending.overload_method(ColumnArrayPointer, 'concat_item')
+def heavydb_column_array_concat_item(x, i, arr):
+    if isinstance(x, ColumnArrayPointer):
+        def impl(x, i, arr):
+            return heavydb_column_array_concatitem_(deref(x), i, arr)
+        return impl
+    elif isinstance(x, ColumnArrayType):
+        def impl(x, i, arr):
+            return heavydb_column_array_concatitem_(x, i, arr)
+        return impl
+
+
+@extending.overload(len)
+def heavydb_column_array_len(x):
+    if isinstance(x, ColumnArrayPointer):
+        def impl(x):
+            return heavydb_column_array_len_(deref(x))
+        return impl
+    elif isinstance(x, ColumnArrayType):
+        def impl(x):
+            return heavydb_column_array_len_(x)
+        return impl

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -103,6 +103,7 @@ class ColumnArrayPointer(nb_types.Type):
 def heavydb_column_array_getitem_(typingctx, x, i):
     T = x.eltype
     array = typesystem.Type.fromstring(f'Array<{T}>').tonumba().dtype
+    print(T)
     sig = array(x, i)
 
     def codegen(context, builder, sig, args):

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -90,7 +90,7 @@ class ColumnArray(metaclass=HeavyDBMetaType):
     def __len__(self) -> int:
         """
         Return the length of the array.
-        
+
         ..  note::
              Only available on ``CPU``
         """

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -5,13 +5,14 @@ Heavydb Column<Array<T>> type is the type of input/output column arguments in
 UDTFs.
 """
 
-__all__ = ['HeavyDBOutputColumnArrayType', 'HeavyDBColumnArrayType']
+__all__ = ['HeavyDBOutputColumnArrayType', 'HeavyDBColumnArrayType', 'ColumnArray']
 
 import operator
 from typing import TypeVar
 from rbc import typesystem
-from .column import HeavyDBColumnType, Column
-from .array import Array
+from .column import HeavyDBColumnType
+from . import array
+from .metatype import HeavyDBMetaType
 from numba.core import extending, cgutils
 from numba.core import types as nb_types
 from llvmlite import ir
@@ -32,7 +33,7 @@ void = ir.VoidType()
 _COLUMN_PARAM_NAME = 'ColumnArray_inner_type'
 
 
-class ColumnArray(Column):
+class ColumnArray(metaclass=HeavyDBMetaType):
     """
     RBC ``Column<Array<T>>`` type that corresponds to HeavyDB COLUMN<ARRAY<T>>
 
@@ -54,15 +55,15 @@ class ColumnArray(Column):
             Only available on ``CPU``
         """
 
-    def set_item(self, index: int, arr: Array[T]) -> int:
+    def set_item(self, index: int, arr: 'array.Array[T]') -> int:
         """
-        ``self[index] = arr
+        ``self[index] = arr``
 
         .. note::
             Only available on ``CPU``
         """
 
-    def concat_item(self, index: int, arr: Array[T]) -> int:
+    def concat_item(self, index: int, arr: 'array.Array[T]') -> int:
         """
         Concat array ``arr`` at ``index``.
 

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -1,0 +1,79 @@
+
+"""Implement Heavydb Column<Array<T>> type support
+
+Heavydb Column<Array<T>> type is the type of input/output column arguments in
+UDTFs.
+"""
+
+# __all__ = ['OutputColumn', 'Column', 'HeavyDBOutputColumnType', 'HeavyDBColumnType',
+#            'HeavyDBCursorType']
+
+import operator
+from rbc import typesystem
+from .column import HeavyDBColumnType
+from .buffer import BufferType, BufferPointer
+from numba.core import extending
+from numba.core import types as nb_types
+
+
+class HeavyDBColumnArrayType(HeavyDBColumnType):
+
+    def postprocess_type(self):
+        return self
+
+    @property
+    def numba_type(self):
+        return ColumnArrayType
+
+    @property
+    def numba_pointer_type(self):
+        return ColumnArrayPointer
+
+    @property
+    def element_type(self):
+        return typesystem.Type.fromstring('int8_t')
+
+
+class ColumnArrayType(nb_types.Type):
+    """Numba type class for HeavyDB buffer structures.
+    """
+
+    def __init__(self, dtype):
+        breakpoint()
+
+    @property
+    def eltype(self):
+        """
+        Return buffer element dtype.
+        """
+        return self.members[0].dtype
+
+    # @property
+    # def iterator_type(self):
+    #     return BufferIteratorType(self)
+
+
+class ColumnArrayPointer(nb_types.Type):
+    """Numba type class for pointers to HeavyDB buffer structures.
+
+    We are not deriving from CPointer because BufferPointer getitem is
+    used to access the data stored in Buffer ptr member.
+    """
+    mutable = True
+    return_as_first_argument = True
+
+    def __init__(self, dtype):
+        self.dtype = dtype    # struct dtype
+        self.eltype = dtype.eltype  # buffer element dtype
+        name = "%s[%s]*" % (type(self).__name__, dtype)
+        super().__init__(name)
+
+    @property
+    def key(self):
+        return self.dtype
+
+
+@extending.overload(operator.getitem)
+def heavydb_buffer_getitem(x, i):
+    if isinstance(x, ColumnArrayPointer):
+        breakpoint()

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -48,7 +48,8 @@ class HeavyDBColumnArrayType(HeavyDBColumnType):
     def custom_params(self):
         return {
             **super().custom_params,
-            _COLUMN_PARAM_NAME: self[0][0]
+            _COLUMN_PARAM_NAME: self[0][0],
+            'name': f'STRUCT_{self.mangling()}_{self[0][0][0][0].tostring()}'
         }
 
 
@@ -72,6 +73,10 @@ class ColumnArrayType(nb_types.Type):
         super().__init__(name)
 
     @property
+    def key(self):
+        return self.dtype
+
+    @property
     def eltype(self):
         """
         Return buffer element dtype.
@@ -91,7 +96,7 @@ class ColumnArrayPointer(nb_types.Type):
     def __init__(self, dtype):
         self.dtype = dtype    # struct dtype
         self.eltype = dtype.eltype  # buffer element dtype
-        name = "%s[%s]*" % (type(self).__name__, dtype)
+        name = f"Column<Array<{self.eltype}>>*"
         super().__init__(name)
 
     @property
@@ -103,7 +108,6 @@ class ColumnArrayPointer(nb_types.Type):
 def heavydb_column_array_getitem_(typingctx, x, i):
     T = x.eltype
     array = typesystem.Type.fromstring(f'Array<{T}>').tonumba().dtype
-    print(T)
     sig = array(x, i)
 
     def codegen(context, builder, sig, args):

--- a/rbc/heavydb/column_array.py
+++ b/rbc/heavydb/column_array.py
@@ -89,6 +89,10 @@ class ColumnArray(metaclass=HeavyDBMetaType):
 
     def __len__(self) -> int:
         """
+        Return the length of the array.
+        
+        ..  note::
+             Only available on ``CPU``
         """
 
 

--- a/rbc/heavydb/column_list.py
+++ b/rbc/heavydb/column_list.py
@@ -4,14 +4,15 @@ __all__ = ['HeavyDBColumnListType', 'ColumnList']
 import operator
 from numba.core import extending, cgutils, datamodel, imputils
 
-from rbc.heavydb.buffer import Buffer
+from .buffer import Buffer
+from .abstract_type import HeavyDBAbstractType
 from numba.core import types as nb_types
 from rbc.typesystem import Type
 from rbc import structure_type
 from rbc.targetinfo import TargetInfo
 
 
-class HeavyDBColumnListType(Type):
+class HeavyDBColumnListType(HeavyDBAbstractType):
 
     def postprocess_type(self):
         if self.tostring().startswith('HeavyDBColumnListType<HeavyDBArrayType'):
@@ -34,14 +35,9 @@ class HeavyDBColumnListType(Type):
     def numba_pointer_type(self):
         return ColumnListType
 
-    # @property
-    # def numba_type(self):
-    #     return ColumnList
-
     @property
     def custom_params(self):
         return {
-            # 'NumbaType': self.numba_type,
             'NumbaPointerType': self.numba_pointer_type,
         }
 

--- a/rbc/heavydb/column_list.py
+++ b/rbc/heavydb/column_list.py
@@ -13,6 +13,12 @@ from rbc.targetinfo import TargetInfo
 
 class HeavyDBColumnListType(Type):
 
+    def postprocess_type(self):
+        if self.tostring().startswith('HeavyDBColumnListType<HeavyDBArrayType'):
+            from .column_list_array import HeavyDBColumnListArrayType
+            return self.copy(cls=HeavyDBColumnListArrayType)
+        return self
+
     @property
     def element_type(self):
         return self[0][0]
@@ -25,13 +31,35 @@ class HeavyDBColumnListType(Type):
         return ()
 
     @property
-    def __typesystem_type__(self):
-        ptrs_t = self.element_type.pointer().pointer().params(name='ptrs')
-        length_t = Type.fromstring('int64 length')
-        size_t = Type.fromstring('int64 size')
+    def numba_pointer_type(self):
+        return ColumnListType
+
+    # @property
+    # def numba_type(self):
+    #     return ColumnList
+
+    @property
+    def custom_params(self):
+        return {
+            # 'NumbaType': self.numba_type,
+            'NumbaPointerType': self.numba_pointer_type,
+        }
+
+    def tonumba(self, bool_is_int8=None):
+        ptrs = self.element_type.pointer().pointer().params(name='ptrs')
+        ncols = Type.fromstring('int64 num_cols_')
+        nrows = Type.fromstring('int64 num_rows_')
         extra_members = tuple(map(Type.fromobject, self.buffer_extra_members))
-        return Type(ptrs_t, length_t, size_t, *extra_members).params(
-            NumbaPointerType=ColumnListNumbaType).pointer()
+        extra_members = tuple(map(Type.fromobject, self.buffer_extra_members))
+        column_list_type = Type(
+            ptrs,
+            ncols,
+            nrows,
+            *extra_members
+        )
+        column_list_type.params(other=None, **self.custom_params)
+        numba_type = column_list_type.tonumba(bool_is_int8=True)
+        return self.numba_pointer_type(numba_type)
 
 
 @extending.intrinsic
@@ -56,7 +84,7 @@ def heavydb_columnlist_getitem(typingctx, lst, idx):
         col = col_ctor(context, builder)
 
         col.ptr = builder.load(builder.gep(collist.ptrs, [idx]))
-        col.sz = collist.size
+        col.sz = collist.num_rows_
         if is_text_encoding_dict:
             col.string_dict_proxy_ = builder.load(builder.gep(collist.string_dict_proxy_, [idx]))
         return col._getvalue()
@@ -74,8 +102,8 @@ class ColumnList(Buffer):
 
         {
             T** ptrs;
-            int64_t nrows;
-            int64_t ncols;
+            int64_t num_cols_;
+            int64_t num_rows_;
         }
 
     """
@@ -93,7 +121,7 @@ class ColumnList(Buffer):
         """
 
 
-class ColumnListNumbaType(structure_type.StructureNumbaPointerType, nb_types.IterableType):
+class ColumnListType(structure_type.StructureNumbaPointerType, nb_types.IterableType):
     def get_getitem_impl(self):
         def impl(x, i):
             return heavydb_columnlist_getitem(x, i)
@@ -122,17 +150,17 @@ class BufferPointerIteratorModel(datamodel.StructModel):
         super(BufferPointerIteratorModel, self).__init__(dmm, fe_type, members)
 
 
-@extending.overload_attribute(ColumnListNumbaType, 'nrows')
+@extending.overload_attribute(ColumnListType, 'nrows')
 def get_nrows(clst):
     def impl(clst):
-        return clst.size
+        return clst.num_rows_
     return impl
 
 
-@extending.overload_attribute(ColumnListNumbaType, 'ncols')
+@extending.overload_attribute(ColumnListType, 'ncols')
 def get_ncols(clst):
     def impl(clst):
-        return clst.length
+        return clst.num_cols_
     return impl
 
 
@@ -149,7 +177,7 @@ def iternext_BufferPointer(context, builder, sig, args, result):
 
     lst = context.make_helper(builder, iterbufty.buffer_type.dtype,
                               value=builder.load(buf))
-    count = lst.length
+    count = lst.num_cols_
 
     is_valid = builder.icmp_signed('<', idx, count)
     result.set_valid(is_valid)
@@ -164,7 +192,7 @@ def iternext_BufferPointer(context, builder, sig, args, result):
         builder.store(nidx, iterval.index)
 
 
-@extending.lower_builtin('getiter', ColumnListNumbaType)
+@extending.lower_builtin('getiter', ColumnListType)
 def getiter_buffer_pointer(context, builder, sig, args):
     [buffer] = args
 

--- a/rbc/heavydb/column_list_array.py
+++ b/rbc/heavydb/column_list_array.py
@@ -1,0 +1,157 @@
+
+"""Implement Heavydb Column<Array<T>> type support
+
+Heavydb Column<Array<T>> type is the type of input/output column arguments in
+UDTFs.
+"""
+
+__all__ = ['HeavyDBColumnListArrayType']
+
+import operator
+from rbc import typesystem
+from .column_list import HeavyDBColumnListType
+from numba.core import extending, cgutils
+from numba.core import types as nb_types
+from llvmlite import ir
+
+
+i1 = ir.IntType(1)
+i8 = ir.IntType(8)
+i8p = i8.as_pointer()
+i8pp = i8p.as_pointer()
+i64 = ir.IntType(64)
+i64p = i64.as_pointer()
+void = ir.VoidType()
+
+
+_COLUMN_PARAM_NAME = 'ColumnListArray_inner_type'
+
+
+class HeavyDBColumnListArrayType(HeavyDBColumnListType):
+
+    def postprocess_type(self):
+        return self
+
+    @property
+    def numba_type(self):
+        return ColumnListArrayType
+
+    @property
+    def numba_pointer_type(self):
+        return ColumnListArrayPointer
+
+    @property
+    def element_type(self):
+        return typesystem.Type.fromstring('int8_t')
+
+    @property
+    def custom_params(self):
+        return {
+            'NumbaType': self.numba_type,
+            'NumbaPointerType': self.numba_pointer_type,
+            _COLUMN_PARAM_NAME: self[0][0]
+        }
+
+
+class ColumnListArrayType(nb_types.Type):
+    """Numba type class for HeavyDB ColumnList<Array<T>> structures.
+    """
+
+    def __init__(self, dtype):
+        array_T = self.__typesystem_type__._params.get(_COLUMN_PARAM_NAME)
+        eltype = array_T.tonumba().eltype
+        self.dtype = array_T.tonumba()  # struct dtype
+        name = f"ColumnList<Array<{eltype}>>"
+        super().__init__(name)
+
+    @property
+    def eltype(self):
+        """
+        Return buffer element dtype.
+        """
+        return self.dtype.eltype
+
+
+class ColumnListArrayPointer(nb_types.Type):
+    """Numba type class for pointers to HeavyDB buffer structures.
+
+    We are not deriving from CPointer because ColumnListArrayPointer getitem is
+    used to access the data stored in Buffer ptr member.
+    """
+    mutable = True
+    return_as_first_argument = True
+
+    def __init__(self, dtype):
+        self.dtype = dtype    # struct dtype
+        name = "%s[%s]*" % (type(self).__name__, dtype)
+        super().__init__(name)
+
+    @property
+    def key(self):
+        return self.dtype
+
+
+@extending.intrinsic
+def heavydb_column_list_array_nrows_(typingctx, x):
+    sig = nb_types.int64(x)
+
+    def codegen(context, builder, sig, args):
+        [col] = args
+        proxy = cgutils.create_struct_proxy(sig.args[0].dtype)
+        clst = proxy(context, builder, value=builder.load(col))
+        return clst.num_rows_
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_list_array_ncols_(typingctx, x):
+    sig = nb_types.int64(x)
+
+    def codegen(context, builder, sig, args):
+        [col] = args
+        proxy = cgutils.create_struct_proxy(sig.args[0].dtype)
+        clst = proxy(context, builder, value=builder.load(col))
+        return clst.num_cols_
+
+    return sig, codegen
+
+
+@extending.intrinsic
+def heavydb_column_list_array_getitem_(typingctx, x, i):
+    T = x.dtype.eltype
+    col = typesystem.Type.fromstring(f'Column<Array<{T}>>').tonumba().dtype
+    sig = col(x, i)
+
+    def codegen(context, builder, sig, args):
+        ptr, index = args
+        clst = cgutils.create_struct_proxy(sig.args[0].dtype)(
+            context, builder, value=builder.load(ptr))
+        col = cgutils.create_struct_proxy(sig.return_type)(context, builder)
+        col.ptr = builder.load(builder.gep(clst.ptrs, [index]))
+        col.sz = clst.num_rows_
+        return col._getvalue()
+
+    return sig, codegen
+
+
+@extending.overload(operator.getitem)
+def heavydb_column_list_array_getitem(x, i):
+    if isinstance(x, ColumnListArrayPointer):
+        def impl(x, i):
+            return heavydb_column_list_array_getitem_(x, i)
+        return impl
+
+
+@extending.overload_attribute(ColumnListArrayPointer, 'nrows')
+def get_nrows(clst):
+    def impl(clst):
+        return heavydb_column_list_array_nrows_(clst)
+    return impl
+
+
+@extending.overload_attribute(ColumnListArrayPointer, 'ncols')
+def get_ncols(clst):
+    def impl(clst):
+        return heavydb_column_list_array_ncols_(clst)
+    return impl

--- a/rbc/heavydb/column_list_array.py
+++ b/rbc/heavydb/column_list_array.py
@@ -5,11 +5,12 @@ Heavydb Column<Array<T>> type is the type of input/output column arguments in
 UDTFs.
 """
 
-__all__ = ['HeavyDBColumnListArrayType']
+__all__ = ['HeavyDBColumnListArrayType', 'ColumnListArray']
+
 
 import operator
 from rbc import typesystem
-from .column_list import HeavyDBColumnListType
+from .column_list import HeavyDBColumnListType, ColumnList
 from numba.core import extending, cgutils
 from numba.core import types as nb_types
 from llvmlite import ir
@@ -25,6 +26,11 @@ void = ir.VoidType()
 
 
 _COLUMN_PARAM_NAME = 'ColumnListArray_inner_type'
+
+
+class ColumnListArray(ColumnList):
+    """
+    """
 
 
 class HeavyDBColumnListArrayType(HeavyDBColumnListType):

--- a/rbc/heavydb/column_list_array.py
+++ b/rbc/heavydb/column_list_array.py
@@ -49,7 +49,8 @@ class HeavyDBColumnListArrayType(HeavyDBColumnListType):
         return {
             'NumbaType': self.numba_type,
             'NumbaPointerType': self.numba_pointer_type,
-            _COLUMN_PARAM_NAME: self[0][0]
+            _COLUMN_PARAM_NAME: self[0][0],
+            'name': f'STRUCT_{self.mangling()}_{self[0][0][0][0].tostring()}'
         }
 
 

--- a/rbc/heavydb/remoteheavydb.py
+++ b/rbc/heavydb/remoteheavydb.py
@@ -954,6 +954,7 @@ class RemoteHeavyDB(RemoteJIT):
                 ('TextEncodingDict', 'TextEncodingDict'),
                 ('Timestamp', 'Timestamp'),
         ]:
+            # Column<T>
             ext_arguments_map['HeavyDBColumnType<%s>' % ptr_type] \
                 = ext_arguments_map.get('Column<%s>' % T)
             ext_arguments_map['HeavyDBOutputColumnType<%s>' % ptr_type] \
@@ -961,12 +962,20 @@ class RemoteHeavyDB(RemoteJIT):
             if T == 'Timestamp':
                 # timestamp is only defined for Columns
                 continue
+
+            # Array<T>
             ext_arguments_map['HeavyDBArrayType<%s>' % ptr_type] \
                 = ext_arguments_map.get('Array<%s>' % T)
+            # ColumnList<T>
             ext_arguments_map['HeavyDBColumnListType<%s>' % ptr_type] \
                 = ext_arguments_map.get('ColumnList<%s>' % T)
             ext_arguments_map['HeavyDBOutputColumnListType<%s>' % ptr_type] \
                 = ext_arguments_map.get('ColumnList<%s>' % T)
+            # Column<Array<T>>
+            ext_arguments_map[f'HeavyDBColumnArrayType<HeavyDBArrayType<{ptr_type}>>'] \
+                = ext_arguments_map.get(f'ColumnArray<{T}>')
+            ext_arguments_map[f'HeavyDBOutputColumnArrayType<HeavyDBArrayType<{ptr_type}>>'] \
+                = ext_arguments_map.get(f'ColumnArray<{T}>')
 
         ext_arguments_map['HeavyDBTextEncodingNoneType<char8>'] = \
             ext_arguments_map.get('TextEncodingNone')

--- a/rbc/heavydb/remoteheavydb.py
+++ b/rbc/heavydb/remoteheavydb.py
@@ -1402,7 +1402,7 @@ class RemoteHeavyDB(RemoteJIT):
                     atype.annotation(sizer=sizer)
                 elif isinstance(atype, HeavyDBTableFunctionManagerType):
                     continue
-                elif isinstance(atype, HeavyDBOutputColumnType):
+                elif isinstance(atype, (HeavyDBOutputColumnType, HeavyDBOutputColumnArrayType)):
                     rtypes.append(atype.copy(HeavyDBColumnType))
                     continue
                 atypes.append(atype)

--- a/rbc/heavydb/row_function_manager.py
+++ b/rbc/heavydb/row_function_manager.py
@@ -40,11 +40,11 @@ class RowFunctionManager(metaclass=HeavyDBMetaType):
     TRANSIENT_DICT_DB_ID = 0
     TRANSIENT_DICT_ID = 0
 
-    def getString(self, db_id: int, dict_id: int, str_arg: int) -> 'text_encoding_none.TextEncodingNone':
+    def getString(self, db_id: int, dict_id: int, str_arg: int) -> 'text_encoding_none.TextEncodingNone':  # noqa: E501
         """
         """
 
-    def getStringDictionaryProxy(self, db_id: int, dict_id: int) -> 'string_dict_proxy.StringDictionaryProxy':
+    def getStringDictionaryProxy(self, db_id: int, dict_id: int) -> 'string_dict_proxy.StringDictionaryProxy':  # noqa: E501
         """
         """
 

--- a/rbc/heavydb/row_function_manager.py
+++ b/rbc/heavydb/row_function_manager.py
@@ -1,4 +1,4 @@
-__all__ = ['HeavyDBRowFunctionManagerType']
+__all__ = ['HeavyDBRowFunctionManagerType', 'RowFunctionManager']
 
 
 from numba.core import extending, cgutils
@@ -8,10 +8,13 @@ from rbc import structure_type
 from rbc.errors import UnsupportedError, RequireLiteralValue
 from rbc.targetinfo import TargetInfo
 from rbc.typesystem import Type
+from .abstract_type import HeavyDBAbstractType
+from .metatype import HeavyDBMetaType
+from . import text_encoding_none, string_dict_proxy
 from llvmlite import ir
 
 
-class HeavyDBRowFunctionManagerType(Type):
+class HeavyDBRowFunctionManagerType(HeavyDBAbstractType):
     """RowFunctionManager<> is a typesystem custom type that
     represents a class type with the following public interface:
 
@@ -27,6 +30,31 @@ class HeavyDBRowFunctionManagerType(Type):
 
 class HeavyDBRowFunctionManagerNumbaType(structure_type.StructureNumbaPointerType):
     pass
+
+
+class RowFunctionManager(metaclass=HeavyDBMetaType):
+    """
+    TableFunctionManager is available in HeavyDB 6.2 or newer
+    """
+
+    TRANSIENT_DICT_DB_ID = 0
+    TRANSIENT_DICT_ID = 0
+
+    def getString(self, db_id: int, dict_id: int, str_arg: int) -> 'text_encoding_none.TextEncodingNone':
+        """
+        """
+
+    def getStringDictionaryProxy(self, db_id: int, dict_id: int) -> 'string_dict_proxy.StringDictionaryProxy':
+        """
+        """
+
+    def getDictDbId(self, func_name: str, arg_idx: int) -> int:
+        """
+        """
+
+    def getDictId(self, func_name: str, arg_idx: int) -> int:
+        """
+        """
 
 
 error_msg = 'RowFunctionManager is only available in HeavyDB 6.2 or newer (got %s)'

--- a/rbc/heavydb/row_function_manager.py
+++ b/rbc/heavydb/row_function_manager.py
@@ -8,13 +8,12 @@ from rbc import structure_type
 from rbc.errors import UnsupportedError, RequireLiteralValue
 from rbc.targetinfo import TargetInfo
 from rbc.typesystem import Type
-from .abstract_type import HeavyDBAbstractType
 from .metatype import HeavyDBMetaType
 from . import text_encoding_none, string_dict_proxy
 from llvmlite import ir
 
 
-class HeavyDBRowFunctionManagerType(HeavyDBAbstractType):
+class HeavyDBRowFunctionManagerType(Type):
     """RowFunctionManager<> is a typesystem custom type that
     represents a class type with the following public interface:
 

--- a/rbc/heavydb/string_dict_proxy.py
+++ b/rbc/heavydb/string_dict_proxy.py
@@ -32,6 +32,7 @@ class StringDictionaryProxy(metaclass=HeavyDBMetaType):
         """
         """
 
+
 class StringDictionaryProxyNumbaType(nb_types.Type):
     def __init__(self):
         super().__init__(name='StringDictionaryProxy')

--- a/rbc/heavydb/string_dict_proxy.py
+++ b/rbc/heavydb/string_dict_proxy.py
@@ -1,7 +1,7 @@
 '''RBC String Dictionary Proxy type
 '''
 
-__all__ = ['StringDictionaryProxyNumbaType']
+__all__ = ['StringDictionaryProxyNumbaType', 'StringDictionaryProxy']
 
 
 from numba.core import extending, datamodel, cgutils
@@ -9,12 +9,28 @@ from numba.core import types as nb_types
 from rbc.errors import NumbaTypeError
 from rbc.heavydb.buffer import heavydb_buffer_constructor
 from rbc.typesystem import Type
+from .metatype import HeavyDBMetaType
+from . import text_encoding_none
 from llvmlite import ir
 
 
 int8_t = ir.IntType(8)
 int32_t = ir.IntType(32)
 
+
+class StringDictionaryProxy(metaclass=HeavyDBMetaType):
+
+    def getStringId(self, str_arg: 'text_encoding_none.TextEncodingNone') -> int:
+        """
+        """
+
+    def getOrAddTransient(self, str_arg: 'text_encoding_none.TextEncodingNone') -> int:
+        """
+        """
+
+    def getString(self, index: int) -> 'text_encoding_none.TextEncodingNone':
+        """
+        """
 
 class StringDictionaryProxyNumbaType(nb_types.Type):
     def __init__(self):

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -32,6 +32,35 @@ class HeavyDBTableFunctionManagerNumbaType(structure_type.StructureNumbaPointerT
     pass
 
 
+class TableFunctionManager:
+    """
+    TableFunctionManager is available in HeavyDB 5.9 or newer
+    """
+
+    def set_output_row_size(self, size: int) -> None:
+        """
+        Set the number of rows in an output column.
+
+        .. note::
+            Must be called before any assignment on output columns.
+        """
+
+    def error_message(self, msg: str) -> None:
+        """
+        .. note::
+            ``msg`` must be known at compile-time.
+        """
+
+    def set_output_array_values_total_number(self, index: int,
+                                             output_array_values_total_number: int) -> None:
+        """
+        Set the total number of array values in a column of arrays.
+
+        .. note::
+            Must be called before making any assignment on output columns.
+        """
+
+
 error_msg = 'TableFunctionManager is only available in HeavyDB 5.9 or newer (got %s)'
 i8p = ir.IntType(8).as_pointer()
 i32 = ir.IntType(32)

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -1,4 +1,4 @@
-__all__ = ['HeavyDBTableFunctionManagerType']
+__all__ = ['HeavyDBTableFunctionManagerType', 'TableFunctionManager']
 
 
 from numba.core import extending, types, cgutils
@@ -7,10 +7,12 @@ from rbc import structure_type
 from rbc.errors import UnsupportedError, RequireLiteralValue
 from rbc.targetinfo import TargetInfo
 from rbc.typesystem import Type
+from .abstract_type import HeavyDBAbstractType
+from .metatype import HeavyDBMetaType
 from llvmlite import ir
 
 
-class HeavyDBTableFunctionManagerType(Type):
+class HeavyDBTableFunctionManagerType(HeavyDBAbstractType):
     """TableFunctionManager<> is a typesystem custom type that
     represents a class type with the following public interface:
 
@@ -32,7 +34,7 @@ class HeavyDBTableFunctionManagerNumbaType(structure_type.StructureNumbaPointerT
     pass
 
 
-class TableFunctionManager:
+class TableFunctionManager(metaclass=HeavyDBMetaType):
     """
     TableFunctionManager is available in HeavyDB 5.9 or newer
     """

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -133,6 +133,7 @@ def heavydb_udtfmanager_set_output_row_size(mgr, num_rows):
 
 set_output_array = 'set_output_array_values_total_number'
 
+
 @extending.overload_method(HeavyDBTableFunctionManagerNumbaType, set_output_array)
 def mgr_set_output_array(mgr, col_idx, value):
     def impl(mgr, col_idx, value):

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -7,12 +7,11 @@ from rbc import structure_type
 from rbc.errors import UnsupportedError, RequireLiteralValue
 from rbc.targetinfo import TargetInfo
 from rbc.typesystem import Type
-from .abstract_type import HeavyDBAbstractType
 from .metatype import HeavyDBMetaType
 from llvmlite import ir
 
 
-class HeavyDBTableFunctionManagerType(HeavyDBAbstractType):
+class HeavyDBTableFunctionManagerType(Type):
     """TableFunctionManager<> is a typesystem custom type that
     represents a class type with the following public interface:
 

--- a/rbc/libfuncs.py
+++ b/rbc/libfuncs.py
@@ -53,6 +53,7 @@ class HeavyDB(Library):
     _function_names = list('''
     allocate_varlen_buffer set_output_row_size
     TableFunctionManager_error_message TableFunctionManager_set_output_row_size
+    TableFunctionManager_set_output_array_values_total_number
     table_function_error
     extract_epoch extract_dateepoch extract_quarterday extract_hour
     extract_minute extract_second extract_millisecond extract_nanosecond
@@ -64,6 +65,8 @@ class HeavyDB(Library):
     StringDictionaryProxy_getStringId
     RowFunctionManager_getStringDictionaryProxy RowFunctionManager_getDictId
     RowFunctionManager_getDictDbId
+    ColumnArray_isNull ColumnArray_setNull ColumnArray_getItem
+    ColumnArray_setItem ColumnArray_concatItem
     '''.strip().split())
 
 

--- a/rbc/tests/__init__.py
+++ b/rbc/tests/__init__.py
@@ -129,7 +129,7 @@ class _arrayTestTable(_DefaultTestTable):
     @property
     def sqltypes(self):
         return ('FLOAT[]', 'DOUBLE[]', 'TINYINT[]', 'SMALLINT[]', 'INT[]', 'BIGINT[]',
-                'BOOLEAN[]', 'TEXT[] ENCODING DICT')
+                'BOOLEAN[]')
 
     @property
     def values(self):
@@ -141,7 +141,6 @@ class _arrayTestTable(_DefaultTestTable):
             'i4': [[], [1], [2, 3], [3, 4, 5], [4, 5, 6, 7]],
             'i8': [[], [1], [2, 3], [3, 4, 5], [4, 5, 6, 7]],
             'b': [[], [False], [True, False], [False, True, False], [True, False, True, False]],
-            't': [[], ['a'], ['a', 'b'], ['a', 'b', 'c'], ['a', 'b', 'c', 'd']],
         }
 
 

--- a/rbc/tests/__init__.py
+++ b/rbc/tests/__init__.py
@@ -129,7 +129,7 @@ class _arrayTestTable(_DefaultTestTable):
     @property
     def sqltypes(self):
         return ('FLOAT[]', 'DOUBLE[]', 'TINYINT[]', 'SMALLINT[]', 'INT[]', 'BIGINT[]',
-                'BOOLEAN[]')
+                'BOOLEAN[]', 'TEXT[] ENCODING DICT')
 
     @property
     def values(self):
@@ -141,6 +141,7 @@ class _arrayTestTable(_DefaultTestTable):
             'i4': [[], [1], [2, 3], [3, 4, 5], [4, 5, 6, 7]],
             'i8': [[], [1], [2, 3], [3, 4, 5], [4, 5, 6, 7]],
             'b': [[], [False], [True, False], [False, True, False], [True, False, True, False]],
+            't': [[], ['a'], ['a', 'b'], ['a', 'b', 'c'], ['a', 'b', 'c', 'd']],
         }
 
 
@@ -203,10 +204,6 @@ class _TextTestTable(_TestTable):
         return ('TEXT ENCODING DICT(32)', 'TEXT ENCODING DICT(16)',
                 'TEXT ENCODING DICT(8)', 'TEXT[] ENCODING DICT(32)',
                 'TEXT ENCODING NONE', 'TEXT ENCODING NONE')
-
-    @property
-    def colnames(self):
-        return ('t4', 't2', 't1', 's', 'n', 'n2')
 
     @property
     def values(self):

--- a/rbc/tests/heavydb/test_column_array.py
+++ b/rbc/tests/heavydb/test_column_array.py
@@ -12,37 +12,60 @@ def heavydb():
 
 def define(heavydb):
     @heavydb("int32(TableFunctionManager, Column<Array<T>> inp, OutputColumn<Array<T>> out | input_id=args<0>)",  # noqa: E501
-             T=['bool', 'int8', 'int16', 'int32', 'int64', 'float', 'double', 'TextEncodingDict'],
-             devices=['cpu'])
-    def test_column_array(mgr, inp, out):
+             T=['int64', 'double', 'TextEncodingDict'], devices=['cpu'])
+    def rbc_array_copy(mgr, inp, out):
         sz = len(inp)
         output_values_size = 0
-        # for i in range(sz):
-        #     output_values_size += len(inp[i])
-        output_values_size += len(inp[0])
+        for i in range(sz):
+            output_values_size += len(inp[i])
 
-        # # initialize array buffers
-        # mgr.set_output_array_values_total_number(0, output_values_size)
+        # initialize array buffers
+        mgr.set_output_array_values_total_number(0, output_values_size)
 
-        out.is_null(0)
-        # mgr.set_output_row_size(sz)
-        # for i in range(sz):
-        #     if inp.is_null(i):
-        #         out.set_null(i)
-        #     else:
-        #         out.set_item(i, inp[i])
+        mgr.set_output_row_size(sz)
+        for i in range(sz):
+            if inp.is_null(i):
+                out.set_null(i)
+            else:
+                out.set_item(i, inp[i])
         return sz
+
+    @heavydb('int32(TableFunctionManager, ColumnList<Array<T>> lst, OutputColumn<Array<T>> out | input_id=args<0>)',  # noqa: E501
+             T=['int64', 'double', 'TextEncodingDict'], devices=['cpu'])
+    def rbc_array_concat(mgr, lst, out):
+        output_values_size = 0
+
+        for j in range(lst.ncols):
+            for i in range(lst.nrows):
+                output_values_size += len(lst[j][i])
+
+        mgr.set_output_array_values_total_number(
+            0,  # output column index
+            output_values_size,  # upper bound to the number of items
+                                 # in all output arrays
+        )
+
+        size = lst.nrows
+        mgr.set_output_row_size(size)
+
+        for i in range(lst.nrows):
+            for j in range(lst.ncols):
+                col = lst[j]
+                arr = col[i]
+                out.concat_item(i, arr)
+
+        return size
 
     heavydb.register()
 
 
 @pytest.mark.parametrize("suffix", ['array', 'arraynull'])
-@pytest.mark.parametrize("col", ['b', 'i1', 'i2', 'i4', 'i8', 'f4', 'f8'])
+@pytest.mark.parametrize("col", ['i8', 'f8'])
 def test_copy(heavydb, suffix, col):
     if heavydb.version[:2] < (6, 3):
         pytest.skip('Requires HeavyDB 6.3 or newer')
 
-    query = (f'select * from table(test_column_array(cursor(select {col} '
+    query = (f'select * from table(rbc_array_copy(cursor(select {col} '
              f'from {heavydb.table_name}{suffix})));')
     _, result = heavydb.sql_execute(query)
 
@@ -55,17 +78,68 @@ def test_copy(heavydb, suffix, col):
     assert result == expected
 
 
-@pytest.mark.parametrize("col", ['s'])
-def test_copy_text_encoding_dict(heavydb, col):
+@pytest.mark.parametrize("col", ['s', 'na'])
+def test_copy_text(heavydb, col):
     if heavydb.version[:2] < (6, 3):
         pytest.skip('Requires HeavyDB 6.3 or newer')
 
-    query = (f'select * from table(test_column_array(cursor(select {col} '
+    if col == 'na':
+        pytest.skip('Column<Array<TextEncodingNone>> is not supported yet.')
+
+    query = (f'select * from table(rbc_array_copy(cursor(select {col} '
              f'from {heavydb.table_name}text)));')
     _, result = heavydb.sql_execute(query)
 
     query = (f'select {col} from {heavydb.table_name}text')
     _, expected = heavydb.sql_execute(query)
+
+    result = list(result)
+    expected = list(expected)
+    assert len(result) == len(expected) == 5
+    assert result == expected
+
+
+@pytest.mark.parametrize("suffix", ['array', 'arraynull'])
+@pytest.mark.parametrize("col", ['i8', 'f8'])
+def test_concat(heavydb, suffix, col):
+    if heavydb.version[:2] < (6, 3):
+        pytest.skip('Requires HeavyDB 6.3 or newer')
+
+    query = (f'select * from table(rbc_array_concat(cursor(select {col}, {col} '
+             f'from {heavydb.table_name}{suffix})));')
+    _, result = heavydb.sql_execute(query)
+
+    query = (f'select {col}, {col} from {heavydb.table_name}{suffix}')
+    _, expected = heavydb.sql_execute(query)
+
+    result = list(result)
+    expected = list(expected)
+    assert len(result) == len(expected) == 5
+    for a, (b, c) in zip(result, expected):
+        if a == (None,):
+            assert b is None and c is None
+        else:
+            assert a == (b + c,)
+
+
+@pytest.mark.parametrize("col", ['s', 'na'])
+def test_concat_text(heavydb, col):
+    if heavydb.version[:2] < (6, 3):
+        pytest.skip('Requires HeavyDB 6.3 or newer')
+
+    if col == 's':
+        pytest.xfail('ColumnList<Array<TextEncodingDict>> not supported.')
+
+    if col == 'na':
+        pytest.skip('Column<Array<TextEncodingNone>> is not supported yet.')
+
+    query = (f'select * from table(rbc_array_concat(cursor(select {col} '
+             f'from {heavydb.table_name}text)));')
+    _, result = heavydb.sql_execute(query)
+
+    query = (f'select {col} from {heavydb.table_name}text')
+    _, expected = heavydb.sql_execute(query)
+
     result = list(result)
     expected = list(expected)
     assert len(result) == len(expected) == 5

--- a/rbc/tests/heavydb/test_column_array.py
+++ b/rbc/tests/heavydb/test_column_array.py
@@ -1,0 +1,42 @@
+import pytest
+from rbc.tests import heavydb_fixture
+
+
+@pytest.fixture(scope='module')
+def heavydb():
+    for o in heavydb_fixture(globals(), minimal_version=(5, 6), suffices=['array']):
+        define(o)
+        yield o
+
+
+def define(heavydb):
+
+    @heavydb("int32(TableFunctionManager, Column<Array<T>> inp, OutputColumn<Array<T>> out)", T=['int64'])
+    def test_column_array(mgr, inp, out):
+        sz = len(inp)
+        output_values_size = 0
+        # for i in range(sz):
+        #     output_values_size += len(inp[i])
+        output_values_size += len(inp[0])
+
+        # # initialize array buffers
+        # mgr.set_output_array_values_total_number(0, output_values_size)
+
+        out.is_null(0)
+        # mgr.set_output_row_size(sz)
+        # for i in range(sz):
+        #     if inp.is_null(i):
+        #         out.set_null(i)
+        #     else:
+        #         out.set_item(i, inp[i])
+        return sz
+
+    heavydb.register()
+
+
+@pytest.mark.parametrize("col", ['i8'])
+def test_copy(heavydb, col):
+    query = (f'select * from table(test_column_array(cursor(select {col} '
+             f'from {heavydb.table_name}array)));')
+    # _, result = heavydb.sql_execute(query)
+    # print(list(result))

--- a/rbc/tests/heavydb/test_column_array.py
+++ b/rbc/tests/heavydb/test_column_array.py
@@ -12,7 +12,7 @@ def heavydb():
 
 def define(heavydb):
     @heavydb("int32(TableFunctionManager, Column<Array<T>> inp, OutputColumn<Array<T>> out | input_id=args<0>)",  # noqa: E501
-             T=['int64', 'double', 'TextEncodingDict'], devices=['cpu'])
+             T=['int64', 'float'], devices=['cpu'])
     def rbc_array_copy(mgr, inp, out):
         sz = len(inp)
         output_values_size = 0
@@ -30,8 +30,27 @@ def define(heavydb):
                 out.set_item(i, inp[i])
         return sz
 
+    @heavydb("int32(TableFunctionManager, Column<Array<T>> inp, OutputColumn<Array<T>> out | input_id=args<0>)",  # noqa: E501
+             T=['TextEncodingDict'], devices=['cpu'])
+    def rbc_array_copy_text(mgr, inp, out):
+        sz = len(inp)
+        output_values_size = 0
+        for i in range(sz):
+            output_values_size += len(inp[i])
+
+        # initialize array buffers
+        mgr.set_output_array_values_total_number(0, output_values_size)
+
+        mgr.set_output_row_size(sz)
+        for i in range(sz):
+            if inp.is_null(i):
+                out.set_null(i)
+            else:
+                out.set_item(i, inp[i])
+        return sz
+
     @heavydb('int32(TableFunctionManager, ColumnList<Array<T>> lst, OutputColumn<Array<T>> out | input_id=args<0>)',  # noqa: E501
-             T=['int64', 'double', 'TextEncodingDict'], devices=['cpu'])
+             T=['int64', 'float'], devices=['cpu'])
     def rbc_array_concat(mgr, lst, out):
         output_values_size = 0
 
@@ -56,11 +75,35 @@ def define(heavydb):
 
         return size
 
-    heavydb.register()
+    @heavydb('int32(TableFunctionManager, ColumnList<Array<T>> lst, OutputColumn<Array<T>> out | input_id=args<0>)',  # noqa: E501
+             T=['TextEncodingDict'], devices=['cpu'])
+    def rbc_array_concat_text(mgr, lst, out):
+        output_values_size = 0
+
+        for j in range(lst.ncols):
+            for i in range(lst.nrows):
+                output_values_size += len(lst[j][i])
+
+        mgr.set_output_array_values_total_number(
+            0,  # output column index
+            output_values_size,  # upper bound to the number of items
+                                 # in all output arrays
+        )
+
+        size = lst.nrows
+        mgr.set_output_row_size(size)
+
+        for i in range(lst.nrows):
+            for j in range(lst.ncols):
+                col = lst[j]
+                arr = col[i]
+                out.concat_item(i, arr)
+
+        return size
 
 
 @pytest.mark.parametrize("suffix", ['array', 'arraynull'])
-@pytest.mark.parametrize("col", ['i8', 'f8'])
+@pytest.mark.parametrize("col", ['i8', 'f4'])
 def test_copy(heavydb, suffix, col):
     if heavydb.version[:2] < (6, 3):
         pytest.skip('Requires HeavyDB 6.3 or newer')
@@ -86,7 +129,7 @@ def test_copy_text(heavydb, col):
     if col == 'na':
         pytest.skip('Column<Array<TextEncodingNone>> is not supported yet.')
 
-    query = (f'select * from table(rbc_array_copy(cursor(select {col} '
+    query = (f'select * from table(rbc_array_copy_text(cursor(select {col} '
              f'from {heavydb.table_name}text)));')
     _, result = heavydb.sql_execute(query)
 
@@ -100,7 +143,7 @@ def test_copy_text(heavydb, col):
 
 
 @pytest.mark.parametrize("suffix", ['array', 'arraynull'])
-@pytest.mark.parametrize("col", ['i8', 'f8'])
+@pytest.mark.parametrize("col", ['i8', 'f4'])
 def test_concat(heavydb, suffix, col):
     if heavydb.version[:2] < (6, 3):
         pytest.skip('Requires HeavyDB 6.3 or newer')
@@ -127,13 +170,10 @@ def test_concat_text(heavydb, col):
     if heavydb.version[:2] < (6, 3):
         pytest.skip('Requires HeavyDB 6.3 or newer')
 
-    if col == 's':
-        pytest.xfail('ColumnList<Array<TextEncodingDict>> not supported.')
-
     if col == 'na':
         pytest.skip('Column<Array<TextEncodingNone>> is not supported yet.')
 
-    query = (f'select * from table(rbc_array_concat(cursor(select {col} '
+    query = (f'select * from table(rbc_array_concat_text(cursor(select {col} '
              f'from {heavydb.table_name}text)));')
     _, result = heavydb.sql_execute(query)
 

--- a/rbc/tests/heavydb/test_column_array.py
+++ b/rbc/tests/heavydb/test_column_array.py
@@ -30,8 +30,6 @@ def define(heavydb):
                 out.set_item(i, inp[i])
         return sz
 
-    heavydb.register()
-
     @heavydb('int32(TableFunctionManager, ColumnList<Array<T>> lst, OutputColumn<Array<T>> out | input_id=args<0>)',  # noqa: E501
              T=['int64', 'float', 'TextEncodingDict'], devices=['cpu'])
     def rbc_array_concat(mgr, lst, out):

--- a/rbc/tests/heavydb/test_column_array.py
+++ b/rbc/tests/heavydb/test_column_array.py
@@ -4,7 +4,7 @@ from rbc.tests import heavydb_fixture
 
 @pytest.fixture(scope='module')
 def heavydb():
-    for o in heavydb_fixture(globals(), minimal_version=(5, 6), suffices=['array']):
+    for o in heavydb_fixture(globals(), minimal_version=(6, 3), suffices=['array']):
         define(o)
         yield o
 

--- a/rbc/tests/heavydb/test_heavydb.py
+++ b/rbc/tests/heavydb/test_heavydb.py
@@ -775,6 +775,8 @@ def test_format_type(heavydb):
     assert test('Column<Array<int32>>') == 'Column<Array<int32>>'
     assert test('Column<Array<TextEncodingNone>>') == 'Column<Array<TextEncodingNone>>'
 
+    assert test('ColumnList<Array<int32>>') == 'ColumnList<Array<int32>>'
+
     assert test('OutputColumn<int32>') == 'OutputColumn<int32>'
     assert test('ColumnList<int32>') == 'ColumnList<int32>'
 

--- a/rbc/tests/heavydb/test_heavydb.py
+++ b/rbc/tests/heavydb/test_heavydb.py
@@ -823,6 +823,8 @@ def test_format_type(heavydb):
     assert test2('UDTF(Constant, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
     assert test2('UDTF(PreFlight, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
     assert test2('UDTF(TableFunctionManager, OutputColumn<int32>)') == '(void) -> (Column<int32>)'
+    assert (test2('UDTF(RowMultiplier, OutputColumn<Array<int32>>)')
+            == '(RowMultiplier) -> (Column<Array<int32>>)')
     assert (test2('UDTF(RowMultiplier, OutputColumn<Array<TextEncodingNone>>)')
             == '(RowMultiplier) -> (Column<Array<TextEncodingNone>>)')
 


### PR DESCRIPTION
Requires https://github.com/heavyai/heavydb-internal/pull/7049

Add bindings for the following functions:
- `Column<Array<T>>::getitem`
- `Column<Array<T>>::setItem`
- `Column<Array<T>>::concatItem`
- `Column<Array<T>>::isNull`
- `Column<Array<T>>::setNull`
- `Column<Array<T>>::setNull`
- `TableFunctionManager::set_output_array_values_total_number`