### PR TITLE
Disable DayTimeInterval tests on GPU

### DIFF
--- a/rbc/heavydb/day_time_interval.py
+++ b/rbc/heavydb/day_time_interval.py
@@ -4,6 +4,7 @@ from rbc import typesystem
 from rbc.heavydb import HeavyDBMetaType
 from rbc.external import external
 from rbc.targetinfo import TargetInfo
+from rbc.errors import UnsupportedError
 from numba.core import extending, cgutils, datamodel
 from numba.core import types as nb_types
 from .timestamp import TimestampNumbaType, Timestamp, kMicroSecsPerSec
@@ -175,6 +176,8 @@ def ol_day_time_interval_operator_add(a, b):
         DateAddHighPrecisionNullable = external(
             "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)|cpu"
         )
+    else:
+        raise UnsupportedError('DateAddHighPrecisionNullable is not supported on GPU')
 
     if isinstance(a, DayTimeIntervalNumbaType) and isinstance(b, TimestampNumbaType):
 
@@ -198,8 +201,6 @@ def ol_day_time_interval_operator_add(a, b):
 
 @extending.overload_method(DayTimeIntervalNumbaType, "numStepsBetween")
 def ol_day_time_interval_numStepBetween_method(dti, begin, end):
-    # importing here to avoid circular dependency error
-
     if isinstance(begin, TimestampNumbaType) and isinstance(end, TimestampNumbaType):
 
         def impl(dti, begin, end):

--- a/rbc/tests/heavydb/test_daytimeinterval.py
+++ b/rbc/tests/heavydb/test_daytimeinterval.py
@@ -20,6 +20,7 @@ def define(heavydb):
         "int32_t(TableFunctionManager, T start, T stop, K step, OutputColumn<T> generate_series)",
         T=["Timestamp"],
         K=["YearMonthTimeInterval", "DayTimeInterval"],
+        devices=['cpu']
     )
     def rbc_generate_series(mgr, start, stop, step, series_output):
         if step.timeval == 0:
@@ -132,7 +133,7 @@ inputs = [
 @pytest.mark.parametrize("start, stop, step, order", inputs)
 def test_generate_time_series(heavydb, start, stop, step, order):
 
-    if heavydb.version[:2] >= (6, 2):
+    if heavydb.version[:2] <= (6, 2):
         pytest.skip('Requires HeavyDB version 6.2 or newer')
 
     RBC_FUNC = "rbc_generate_series"
@@ -181,7 +182,7 @@ invalid_inputs = [
 @pytest.mark.parametrize("start, stop, step, error_msg", invalid_inputs)
 def test_generate_series_invalid_inputs(heavydb, start, stop, step, error_msg):
 
-    if heavydb.version[:2] >= (6, 2):
+    if heavydb.version[:2] <= (6, 2):
         pytest.skip('Requires HeavyDB version 6.2 or newer')
 
     query = (

--- a/rbc/tests/heavydb/test_daytimeinterval.py
+++ b/rbc/tests/heavydb/test_daytimeinterval.py
@@ -182,7 +182,7 @@ invalid_inputs = [
 @pytest.mark.parametrize("start, stop, step, error_msg", invalid_inputs)
 def test_generate_series_invalid_inputs(heavydb, start, stop, step, error_msg):
 
-    if heavydb.version[:2] <= (6, 2):
+    if heavydb.version[:2] < (6, 2):
         pytest.skip('Requires HeavyDB version 6.2 or newer')
 
     query = (

--- a/rbc/tests/heavydb/test_daytimeinterval.py
+++ b/rbc/tests/heavydb/test_daytimeinterval.py
@@ -133,7 +133,7 @@ inputs = [
 @pytest.mark.parametrize("start, stop, step, order", inputs)
 def test_generate_time_series(heavydb, start, stop, step, order):
 
-    if heavydb.version[:2] <= (6, 2):
+    if heavydb.version[:2] < (6, 2):
         pytest.skip('Requires HeavyDB version 6.2 or newer')
 
     RBC_FUNC = "rbc_generate_series"

--- a/rbc/typesystem.py
+++ b/rbc/typesystem.py
@@ -732,6 +732,8 @@ class Type(tuple, metaclass=MetaType):
         return super().__eq__(other)
 
     def __hash__(self) -> int:
+        # Explictly add a hash for Type, otherwise code that depends on Type
+        # being hashable fails
         return super().__hash__()
 
     def tostring(self, use_typename=False, use_annotation=True, use_name=True,
@@ -810,7 +812,6 @@ class Type(tuple, metaclass=MetaType):
                 else:
                     s = str(a)
                 new_params.append(s)
-            # print(name)
             return (name + '<' + ', '.join(new_params) + '>' + suffix)
         raise NotImplementedError(repr(self))
 


### PR DESCRIPTION
This PR changes the condition of the tests to run when server version `>= (6, 2)` and makes the tests CPU-specific.