### PR TITLE
Update thrift files and bump server version to 6.4

### DIFF
--- a/rbc/common.thrift
+++ b/rbc/common.thrift
@@ -27,7 +27,8 @@ enum TDatumType {
   TINYINT,
   GEOMETRY,
   GEOGRAPHY,
-  MULTILINESTRING
+  MULTILINESTRING,
+  MULTIPOINT
 }
 
 enum TEncodingType {

--- a/rbc/heavydb/remoteheavydb.py
+++ b/rbc/heavydb/remoteheavydb.py
@@ -899,6 +899,7 @@ class RemoteHeavyDB(RemoteJIT):
             'GeoMultiPolygon': typemap['TExtArgumentType'].get(
                 'GeoMultiPolygon'),
             'GeoMultiLineString': typemap['TExtArgumentType'].get('GeoMultiLineString'),
+            'GeoMultiPoint': typemap['TExtArgumentType'].get('GeoMultiPoint'),
             'TextEncodingNone': typemap['TExtArgumentType'].get('TextEncodingNone'),
             'TextEncodingDict': typemap['TExtArgumentType'].get('TextEncodingDict'),
             'Timestamp': typemap['TExtArgumentType'].get('Timestamp'),
@@ -922,8 +923,17 @@ class RemoteHeavyDB(RemoteJIT):
                 ('double', 'Double'),
                 ('TextEncodingDict', 'TextEncodingDict'),
                 ('TextEncodingNone', 'TextEncodingNone'),
-                ('Timestamp', 'Timestamp')]:
+                ('Timestamp', 'Timestamp'),
+                ('GeoLineString', 'GeoLineString'),
+                ('GeoPolygon', 'GeoPolygon'),
+                ('GeoMultiPoint', 'GeoMultiPoint'),
+                ('GeoMultiLineString', 'GeoMultiLineString'),
+                ('GeoPoint', 'GeoPoint'),
+                ('GeoMultiPolygon', 'GeoMultiPolygon'),
+                ]:
             ext_arguments_map[f'Column<{T}>'] = typemap['TExtArgumentType'].get(f'Column{Tname}')
+            if T == 'Timestamp':
+                continue
             ext_arguments_map[f'ColumnList<{T}>'] = typemap['TExtArgumentType'].get(
                 f'ColumnList{Tname}')
             ext_arguments_map[f'ColumnArray<{T}>'] = typemap['TExtArgumentType'].get(
@@ -944,12 +954,15 @@ class RemoteHeavyDB(RemoteJIT):
                 ('TextEncodingDict', 'TextEncodingDict'),
                 ('Timestamp', 'Timestamp'),
         ]:
-            ext_arguments_map['HeavyDBArrayType<%s>' % ptr_type] \
-                = ext_arguments_map.get('Array<%s>' % T)
             ext_arguments_map['HeavyDBColumnType<%s>' % ptr_type] \
                 = ext_arguments_map.get('Column<%s>' % T)
             ext_arguments_map['HeavyDBOutputColumnType<%s>' % ptr_type] \
                 = ext_arguments_map.get('Column<%s>' % T)
+            if T == 'Timestamp':
+                # timestamp is only defined for Columns
+                continue
+            ext_arguments_map['HeavyDBArrayType<%s>' % ptr_type] \
+                = ext_arguments_map.get('Array<%s>' % T)
             ext_arguments_map['HeavyDBColumnListType<%s>' % ptr_type] \
                 = ext_arguments_map.get('ColumnList<%s>' % T)
             ext_arguments_map['HeavyDBOutputColumnListType<%s>' % ptr_type] \

--- a/rbc/tests/__init__.py
+++ b/rbc/tests/__init__.py
@@ -308,7 +308,7 @@ def heavydb_fixture(caller_globals, minimal_version=(0, 0),
         if not available_version:
             pytest.skip(reason)
         # Requires update when heavydb-internal bumps up version number:
-        current_development_version = Version("6.3.0")
+        current_development_version = Version("6.4.0")
 
         curr_version = Version('.'.join(map(str, available_version[:2])))
 


### PR DESCRIPTION
Follow up of #518, which updates the server version to 6.4 and add new type definitions to the internal type map.