### PR TITLE
Fix a bug when clang compiler is not available.

### DIFF
--- a/rbc/ctools.py
+++ b/rbc/ctools.py
@@ -42,8 +42,14 @@ class Compiler:
     @staticmethod
     def _get_compilers(_cache=[]):
         if not _cache:
+            from numba import _min_llvm_version
+            v = _min_llvm_version[0]
             # TODO: cuda support
-            for xmode, clang, suffix in [('c++', 'clang++', '.cpp'), ('c', 'clang', '.c')]:
+            for xmode, clang, suffix in [('c++', f'clang++-{v}', '.cpp'),
+                                         ('c++', 'clang++', '.cpp'),
+                                         ('c', f'clang-{v}', '.c'),
+                                         ('c', 'clang', '.c'),
+                                         ]:
                 exe = shutil.which(clang)
                 if exe is not None:
                     s, o = run(exe, '--version')

--- a/rbc/heavydb/remoteheavydb.py
+++ b/rbc/heavydb/remoteheavydb.py
@@ -1374,7 +1374,8 @@ class RemoteHeavyDB(RemoteJIT):
                 compiler = ctools.Compiler.get(std='c')
             if self.debug:
                 print(f'compiler={compiler}')
-
+            if compiler is None:
+                return
             from numba import _min_llvm_version
 
             url = "https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information"  # noqa: E501

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -296,7 +296,10 @@ def compile_instance(func, sig,
                                       library=main_library,
                                       locals={},
                                       pipeline_class=pipeline_class)
-    except (UnsupportedError, nb_errors.TypingError, nb_errors.LoweringError) as msg:
+    except UnsupportedError as msg:
+        warnings.warn(f'Skipping {fname}: {msg.args[1]}')
+        return
+    except (nb_errors.TypingError, nb_errors.LoweringError) as msg:
         for m in re.finditer(r'UnsupportedError(.*?)\n', str(msg), re.S):
             warnings.warn(f'Skipping {fname}:{m.group(0)[18:]}')
             break


### PR DESCRIPTION
As in the title plus improve warning message from UnsupporterError and prefer looking for a clang compiler with a numba specific llvm version.