### PR TITLE
Fix readthedocs build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -90,7 +90,9 @@ html_theme_options = {
    "logo": {
       "image_light": html_logo,
       "image_dark": html_logo,
-   }
+   },
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
 }
 
 html_context = {


### PR DESCRIPTION
ReadTheDocs build is currently failing due to https://github.com/pydata/pydata-sphinx-theme/issues/1220. This PR provides a workaround for the failure.