### PR TITLE
Revise device support

### DIFF
--- a/rbc/external.py
+++ b/rbc/external.py
@@ -2,55 +2,81 @@
 """
 
 # This code has heavily inspired in the numba.extending.intrisic code
+import warnings
 from typing import Dict, List, Union
 from collections import defaultdict
 from numba.core import extending, funcdesc, types, typing
 from rbc.typesystem import Type
 from rbc.targetinfo import TargetInfo
+from rbc.errors import UnsupportedError
+from rbc.utils import validate_devices
 
 
 class External:
+
     @classmethod
-    def external(cls, *args):
-        """
-        Parameters
+    def external(cls, *args, **kwargs):
+        """Parameters
         ----------
         signature : object (str, ctypes function, python callable, numba function)
             Any object convertible to a Numba function via Type.fromobject(...).tonumba()
+
+        Keyword parameters
+        ------------------
+        devices : list
+          Device names ('CPU' or/and 'GPU') for the given set of
+          signatures. Default is ['CPU'].
         """
-        all_possible_devices = {'CPU', 'GPU'}
+        if not args:
+            raise ValueError('specifying at least one signature is required')
+
+        # Default devices contains `CPU` only because in most cases
+        # the externals are defined for the CPU target.
+        devices = validate_devices(kwargs.get('devices', ['CPU']))
+
         ts = defaultdict(list)
-        key = None
+        name = None
         for signature in args:
             with TargetInfo.dummy():
                 t = Type.fromobject(signature)
             if not t.is_function:
                 raise ValueError("signature must represent a function type")
-
             if not t.name:
                 raise ValueError(
                     f"external function name not specified for signature {signature}"
                 )
+            if name is None:
+                name = t.name
+            elif name != t.name:
+                raise ValueError('expected external function name `{name}`, got `{t.name}`')
 
-            if key is None:
-                key = t.name
-            if not key:
-                raise ValueError(
-                    f"external function name not specified for signature {signature}"
-                )
-            signature_devices = [a.upper() for a in (t.annotation() or [])
-                                 if a.upper() in all_possible_devices]
-            devices = signature_devices or all_possible_devices
-            for device in devices:
+            # Using annotation devices (specified via `| CPU` or `| GPU`) is deprecated.
+            # TODO: turn the warning to an exception for rbc version 0.12 or higher
+            annotation_devices = validate_devices([d for d in t.annotation()
+                                                   if d.upper() in {'CPU', 'GPU'}])
+            for d in annotation_devices:
+                warnings.warn(
+                    f'Signature {signature} uses deprecated device annotation (`|{d}`).'
+                    ' Use `devices` kw argument to specify the supported devices of the'
+                    f' external function `{name}`')
+            signature_devices = annotation_devices or devices
+
+            for device in signature_devices:
                 ts[device].append(signature)
 
-        obj = cls(key, dict(ts))
+        # The key must contain devices bit to avoid spurious errors
+        # when externals with the same name but variable device
+        # targets are defined (as exemplified in
+        # tests/heavydb/test_array.py:test_ptr):
+        key = f'{name}-{"-".join(sorted(devices))}'
+        obj = cls(key, name, dict(ts))
         obj.register()
         return obj
 
     def __init__(
         self,
         key: str,
+        name: str,
         signatures: Dict[str, List[Union[str, types.FunctionType, Type]]],
     ):
         """
@@ -58,11 +84,14 @@ class External:
         ----------
         key : str
             The key of the external function for typing
+        name : str
+            The name of the external function
         signatures : Dictionary of devices and function signatures
             A device mapping of a list of function type signature
         """
         self._signatures = signatures
         self.key = key
+        self.name = name
 
     def __str__(self):
         a = []
@@ -71,22 +100,26 @@ class External:
                 a.append(str(t))
         return ", ".join(a)
 
-    @property
-    def name(self):
-        return self.key
-
     def match_signature(self, atypes):
         # Code here is the same found in remotejit.py::Signature::best_match
         target_info = TargetInfo()
         device = "CPU" if target_info.is_cpu else "GPU"
         if device not in self._signatures:
-            satypes = ", ".join(map(str, atypes))
             compile_target = target_info.get_compile_target()
-            raise TypeError(
-                f"{compile_target=}: no signatures with argument types `{satypes}` and"
-                f" device `{device}` while processing `{self.name}`"
-                " (perhaps the compile target cannot support the device?)"
-            )
+            # Raising UnsupportedError will skip compiling the compile
+            # target for the given device. This could also be skipped
+            # by specifying the desired device in the devices kw
+            # argument of a RemoteJIT decorator.
+            if device == 'GPU':
+                raise UnsupportedError(
+                    f'no {device} specific signatures found for the external function'
+                    f' `{self.name}` that is referenced by `{compile_target}`.'
+                    f' Use devices=["CPU"] when defining `{compile_target.split("__", 1)[0]}`')
+            else:
+                raise UnsupportedError(
+                    f'no {device} specific signatures found for the external function'
+                    f' `{self.name}` that is referenced by `{compile_target}`.')
+
         available_types = tuple(map(Type.fromobject, self._signatures[device]))
         ftype = None
         match_penalty = None
@@ -109,7 +142,8 @@ class External:
     def get_codegen(self):
         # lowering
         def codegen(context, builder, sig, args):
-            # Need to retrieve the function name again
+            # Need to retrieve the function name again as the function
+            # implementation may be device specific
             atypes = tuple(map(Type.fromobject, sig.args))
             t = self.match_signature(atypes)
             fn_name = t.name
@@ -123,19 +157,23 @@ class External:
 
     def register(self):
         # typing
-        class ExternalTemplate(typing.templates.AbstractTemplate):
-            obj = self
-            key = self.key
+        def generic(self, args, kws):
+            # get the correct signature and function name for the
+            # current device
+            atypes = tuple(map(Type.fromobject, args))
+            t = self.obj.match_signature(atypes)
+            TargetInfo().add_external(t.name)
 
-            def generic(self, args, kws):
-                # get the correct signature and function name for the current device
-                atypes = tuple(map(Type.fromobject, args))
-                t = self.obj.match_signature(atypes)
-                TargetInfo().add_external(t.name)
+            codegen = self.obj.get_codegen()
+            t_numba = t.tonumba()
+            extending.lower_builtin(self.key, *t_numba.args)(codegen)
+            return t_numba
 
-                codegen = self.obj.get_codegen()
-                extending.lower_builtin(self.key, *t.tonumba().args)(codegen)
-                return t.tonumba()
+        ExternalTemplate = type(f"ExternalTemplate_{self.name}",
+                                (typing.templates.AbstractTemplate,),
+                                dict(generic=generic,
+                                     obj=self,
+                                     key=self.key))
 
         typing.templates.infer(ExternalTemplate)
         typing.templates.infer_global(self, types.Function(ExternalTemplate))

--- a/rbc/heavydb/day_time_interval.py
+++ b/rbc/heavydb/day_time_interval.py
@@ -174,7 +174,8 @@ def ol_day_time_interval_operator_add(a, b):
     i64_null_val = target_info.null_values["int64"]
     if target_info.is_cpu:
         DateAddHighPrecisionNullable = external(
-            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)|cpu"
+            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)",
+            devices=['CPU']
         )
     else:
         raise UnsupportedError('DateAddHighPrecisionNullable is not supported on GPU')

--- a/rbc/heavydb/day_time_interval.py
+++ b/rbc/heavydb/day_time_interval.py
@@ -174,8 +174,7 @@ def ol_day_time_interval_operator_add(a, b):
     i64_null_val = target_info.null_values["int64"]
     if target_info.is_cpu:
         DateAddHighPrecisionNullable = external(
-            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)",
-            devices=['CPU']
+            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)"
         )
     else:
         raise UnsupportedError('DateAddHighPrecisionNullable is not supported on GPU')

--- a/rbc/heavydb/opaque_pointer.py
+++ b/rbc/heavydb/opaque_pointer.py
@@ -44,7 +44,3 @@ class HeavyDBOpaquePtr(typesystem.Type):
 
     def tonumba(self, bool_is_int8=None):
         return self.numba_type()
-
-    @property
-    def supported_devices(self):
-        return {'CPU', 'GPU'}

--- a/rbc/heavydb/opaque_pointer.py
+++ b/rbc/heavydb/opaque_pointer.py
@@ -44,3 +44,7 @@ class HeavyDBOpaquePtr(typesystem.Type):
 
     def tonumba(self, bool_is_int8=None):
         return self.numba_type()
+
+    @property
+    def supported_devices(self):
+        return {'CPU', 'GPU'}

--- a/rbc/heavydb/remoteheavydb.py
+++ b/rbc/heavydb/remoteheavydb.py
@@ -1468,6 +1468,20 @@ class RemoteHeavyDB(RemoteJIT):
 
         return ftype
 
+    def check_function_type_supports_device(self, ftype: typesystem.Type, device: str):
+        """Check if function type can be supported by the specified device.
+
+        See RemoteJIT.check_function_type_supports_device.__doc__.
+        """
+        if device == 'GPU':
+            for atype in ftype[1]:
+                if isinstance(atype,
+                              (HeavyDBTableFunctionManagerType, HeavyDBRowFunctionManagerType)):
+                    return False
+            if isinstance(ftype[0], (HeavyDBArrayType, HeavyDBTextEncodingNoneType)):
+                return False
+        return True
+
     def format_type(self, typ: typesystem.Type):
         """Convert typesystem type to formatted string.
 

--- a/rbc/heavydb/row_function_manager.py
+++ b/rbc/heavydb/row_function_manager.py
@@ -29,6 +29,10 @@ class HeavyDBRowFunctionManagerType(HeavyDBOpaquePtr):
     def type_name(self):
         return "RowFunctionManager"
 
+    @property
+    def supported_devices(self):
+        return {'CPU'}
+
 
 class RowFunctionManagerNumbaType(OpaquePtrNumbaType):
     pass
@@ -68,7 +72,7 @@ def heavydb_udf_manager_get_dict_id(mgr, func_name, arg_idx):
     if target_info.software[1][:3] < (6, 2, 0):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
-    defn = 'int32 RowFunctionManager_getDictId(int8*, int8*, int32)'
+    defn = 'int32 RowFunctionManager_getDictId(int8*, int8*, int32)|CPU'
     get_dict_id_ = external(defn)
 
     def impl(mgr, func_name, arg_idx):

--- a/rbc/heavydb/row_function_manager.py
+++ b/rbc/heavydb/row_function_manager.py
@@ -29,10 +29,6 @@ class HeavyDBRowFunctionManagerType(HeavyDBOpaquePtr):
     def type_name(self):
         return "RowFunctionManager"
 
-    @property
-    def supported_devices(self):
-        return {'CPU'}
-
 
 class RowFunctionManagerNumbaType(OpaquePtrNumbaType):
     pass
@@ -72,8 +68,8 @@ def heavydb_udf_manager_get_dict_id(mgr, func_name, arg_idx):
     if target_info.software[1][:3] < (6, 2, 0):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
-    defn = 'int32 RowFunctionManager_getDictId(int8*, int8*, int32)|CPU'
-    get_dict_id_ = external(defn)
+    defn = 'int32 RowFunctionManager_getDictId(int8*, int8*, int32)'
+    get_dict_id_ = external(defn, devices=['CPU'])
 
     def impl(mgr, func_name, arg_idx):
         func_name_ = global_str_constant("row_mgr_func_name", func_name)
@@ -87,8 +83,8 @@ def heavydb_udf_manager_get_db_id(mgr, func_name, arg_idx):
     if target_info.software[1][:3] < (6, 2, 0):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
-    defn = 'int32 RowFunctionManager_getDictDbId(int8*, int8*, int32)|CPU'
-    get_dict_db_id_ = external(defn)
+    defn = 'int32 RowFunctionManager_getDictDbId(int8*, int8*, int32)'
+    get_dict_db_id_ = external(defn, devices=['CPU'])
 
     def impl(mgr, func_name, arg_idx):
         func_name_ = global_str_constant("row_mgr_func_name", func_name)
@@ -108,6 +104,7 @@ def heavydb_udf_manager_get_string_dict_proxy(mgr, db_id, dict_id):
     sig = typing.signature(proxy, i8p, i32, i32)
 
     symbol = 'RowFunctionManager_getStringDictionaryProxy'
+    # TODO: define get_string_dict_proxy_ via external signature
     get_string_dict_proxy_ = nb_types.ExternalFunction(symbol, sig)
 
     def impl(mgr, db_id, dict_id):

--- a/rbc/heavydb/row_function_manager.py
+++ b/rbc/heavydb/row_function_manager.py
@@ -69,7 +69,7 @@ def heavydb_udf_manager_get_dict_id(mgr, func_name, arg_idx):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
     defn = 'int32 RowFunctionManager_getDictId(int8*, int8*, int32)'
-    get_dict_id_ = external(defn, devices=['CPU'])
+    get_dict_id_ = external(defn)
 
     def impl(mgr, func_name, arg_idx):
         func_name_ = global_str_constant("row_mgr_func_name", func_name)
@@ -84,7 +84,7 @@ def heavydb_udf_manager_get_db_id(mgr, func_name, arg_idx):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
     defn = 'int32 RowFunctionManager_getDictDbId(int8*, int8*, int32)'
-    get_dict_db_id_ = external(defn, devices=['CPU'])
+    get_dict_db_id_ = external(defn)
 
     def impl(mgr, func_name, arg_idx):
         func_name_ = global_str_constant("row_mgr_func_name", func_name)

--- a/rbc/heavydb/string_dict_proxy.py
+++ b/rbc/heavydb/string_dict_proxy.py
@@ -65,7 +65,8 @@ HeavyDBStringDictProxyType().register_datamodel()
 @extending.overload_method(StringDictionaryProxyNumbaType, 'getStringId')
 @extending.overload_method(StringDictionaryProxyNumbaType, 'getOrAddTransient')
 def ov_getStringId(proxy, str_arg):
-    getStringId_ = external("int32 StringDictionaryProxy_getStringId(int8*, int8*)|CPU")
+    getStringId_ = external("int32 StringDictionaryProxy_getStringId(int8*, int8*)",
+                            devices=['CPU'])
 
     if isinstance(str_arg, nb_types.UnicodeType):
         def impl(proxy, str_arg):
@@ -81,8 +82,10 @@ def ov_getStringId(proxy, str_arg):
 
 @extending.overload_method(StringDictionaryProxyNumbaType, 'getString')
 def heavydb_column_getString(proxy, string_id):
-    getBytes = external('int8* StringDictionaryProxy_getStringBytes(int8*, int32)|CPU')
-    getBytesLength = external('int64 StringDictionaryProxy_getStringLength(int8*, int32)|CPU')
+    getBytes = external('int8* StringDictionaryProxy_getStringBytes(int8*, int32)',
+                        devices=['CPU'])
+    getBytesLength = external('int64 StringDictionaryProxy_getStringLength(int8*, int32)',
+                              devices=['CPU'])
 
     def impl(proxy, string_id):
         ptr = getBytes(as_voidptr(proxy), string_id)

--- a/rbc/heavydb/string_dict_proxy.py
+++ b/rbc/heavydb/string_dict_proxy.py
@@ -50,10 +50,6 @@ class HeavyDBStringDictProxyType(HeavyDBOpaquePtr):
     def type_name(self):
         return "StringDictionaryProxy"
 
-    @property
-    def supported_devices(self):
-        return {'cpu'}
-
 
 class StringDictionaryProxyNumbaType(OpaquePtrNumbaType):
     pass

--- a/rbc/heavydb/string_dict_proxy.py
+++ b/rbc/heavydb/string_dict_proxy.py
@@ -50,6 +50,10 @@ class HeavyDBStringDictProxyType(HeavyDBOpaquePtr):
     def type_name(self):
         return "StringDictionaryProxy"
 
+    @property
+    def supported_devices(self):
+        return {'cpu'}
+
 
 class StringDictionaryProxyNumbaType(OpaquePtrNumbaType):
     pass

--- a/rbc/heavydb/string_dict_proxy.py
+++ b/rbc/heavydb/string_dict_proxy.py
@@ -61,8 +61,7 @@ HeavyDBStringDictProxyType().register_datamodel()
 @extending.overload_method(StringDictionaryProxyNumbaType, 'getStringId')
 @extending.overload_method(StringDictionaryProxyNumbaType, 'getOrAddTransient')
 def ov_getStringId(proxy, str_arg):
-    getStringId_ = external("int32 StringDictionaryProxy_getStringId(int8*, int8*)",
-                            devices=['CPU'])
+    getStringId_ = external("int32 StringDictionaryProxy_getStringId(int8*, int8*)")
 
     if isinstance(str_arg, nb_types.UnicodeType):
         def impl(proxy, str_arg):
@@ -78,10 +77,8 @@ def ov_getStringId(proxy, str_arg):
 
 @extending.overload_method(StringDictionaryProxyNumbaType, 'getString')
 def heavydb_column_getString(proxy, string_id):
-    getBytes = external('int8* StringDictionaryProxy_getStringBytes(int8*, int32)',
-                        devices=['CPU'])
-    getBytesLength = external('int64 StringDictionaryProxy_getStringLength(int8*, int32)',
-                              devices=['CPU'])
+    getBytes = external('int8* StringDictionaryProxy_getStringBytes(int8*, int32)')
+    getBytesLength = external('int64 StringDictionaryProxy_getStringLength(int8*, int32)')
 
     def impl(proxy, string_id):
         ptr = getBytes(as_voidptr(proxy), string_id)

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -79,7 +79,7 @@ def heavydb_udtfmanager_error_message(mgr, msg):
         raise RequireLiteralValue(f"expected StringLiteral but got {type(msg).__name__}")
 
     defn = 'int32_t TableFunctionManager_error_message(int8_t*, int8_t*)'
-    mgr_error_message_ = external(defn, devices=['CPU'])
+    mgr_error_message_ = external(defn)
 
     identifier = "table_function_manager_error_message"
 
@@ -97,7 +97,7 @@ def heavydb_udtfmanager_set_output_row_size(mgr, num_rows):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
     defn = 'void TableFunctionManager_set_output_row_size(int8_t*, int64_t)'
-    mgr_set_output_row_size_ = external(defn, devices=['CPU'])
+    mgr_set_output_row_size_ = external(defn)
 
     def impl(mgr, num_rows):
         return mgr_set_output_row_size_(as_voidptr(mgr), num_rows)
@@ -117,7 +117,7 @@ def mgr_set_output_array(mgr, col_idx, value):
 
     defn = ('void TableFunctionManager_set_output_array_values_total_number'
             '(int8_t*, int32_t, int64_t)')
-    mgr_set_output_array_ = external(defn, devices=['CPU'])
+    mgr_set_output_array_ = external(defn)
 
     def impl(mgr, col_idx, value):
         mgr_set_output_array_(as_voidptr(mgr), col_idx, value)

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -32,10 +32,6 @@ class HeavyDBTableFunctionManagerType(HeavyDBOpaquePtr):
     def type_name(self):
         return 'TableFunctionManager'
 
-    @property
-    def supported_devices(self):
-        return {'CPU'}
-
 
 class TableFunctionManagerNumbaType(OpaquePtrNumbaType):
     pass
@@ -82,8 +78,8 @@ def heavydb_udtfmanager_error_message(mgr, msg):
     if not isinstance(msg, types.StringLiteral):
         raise RequireLiteralValue(f"expected StringLiteral but got {type(msg).__name__}")
 
-    defn = 'int32_t TableFunctionManager_error_message(int8_t*, int8_t*)|CPU'
-    mgr_error_message_ = external(defn)
+    defn = 'int32_t TableFunctionManager_error_message(int8_t*, int8_t*)'
+    mgr_error_message_ = external(defn, devices=['CPU'])
 
     identifier = "table_function_manager_error_message"
 
@@ -100,8 +96,8 @@ def heavydb_udtfmanager_set_output_row_size(mgr, num_rows):
     if target_info.software[1][:3] < (5, 9, 0):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
-    defn = 'void TableFunctionManager_set_output_row_size(int8_t*, int64_t)|CPU'
-    mgr_set_output_row_size_ = external(defn)
+    defn = 'void TableFunctionManager_set_output_row_size(int8_t*, int64_t)'
+    mgr_set_output_row_size_ = external(defn, devices=['CPU'])
 
     def impl(mgr, num_rows):
         return mgr_set_output_row_size_(as_voidptr(mgr), num_rows)
@@ -120,8 +116,8 @@ def mgr_set_output_array(mgr, col_idx, value):
         raise UnsupportedError(error_msg % (".".join(map(str, target_info.software[1]))))
 
     defn = ('void TableFunctionManager_set_output_array_values_total_number'
-            '(int8_t*, int32_t, int64_t)|CPU')
-    mgr_set_output_array_ = external(defn)
+            '(int8_t*, int32_t, int64_t)')
+    mgr_set_output_array_ = external(defn, devices=['CPU'])
 
     def impl(mgr, col_idx, value):
         mgr_set_output_array_(as_voidptr(mgr), col_idx, value)

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -32,6 +32,10 @@ class HeavyDBTableFunctionManagerType(HeavyDBOpaquePtr):
     def type_name(self):
         return 'TableFunctionManager'
 
+    @property
+    def supported_devices(self):
+        return {'CPU'}
+
 
 class TableFunctionManagerNumbaType(OpaquePtrNumbaType):
     pass

--- a/rbc/heavydb/timestamp.py
+++ b/rbc/heavydb/timestamp.py
@@ -315,7 +315,7 @@ def cast_int_to_timestamp(context, builder, fromty, toty, val):
 def heavydb_timestamp_getYear(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_year = external('int64 extract_year(int64)', devices=['CPU'])
+        extract_year = external('int64 extract_year(int64)')
 
         def impl(timestamp):
             return extract_year(timestamp.time // kNanoSecsPerSec)
@@ -326,7 +326,7 @@ def heavydb_timestamp_getYear(timestamp):
 def heavydb_timestamp_getMonth(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_month = external('int64 extract_month(int64)', devices=['CPU'])
+        extract_month = external('int64 extract_month(int64)')
 
         def impl(timestamp):
             return extract_month(timestamp.time // kNanoSecsPerSec)
@@ -337,7 +337,7 @@ def heavydb_timestamp_getMonth(timestamp):
 def heavydb_timestamp_getDay(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_day = external('int64 extract_day(int64)', devices=['CPU'])
+        extract_day = external('int64 extract_day(int64)')
 
         def impl(timestamp):
             return extract_day(timestamp.time // kNanoSecsPerSec)
@@ -348,7 +348,7 @@ def heavydb_timestamp_getDay(timestamp):
 def heavydb_timestamp_getHours(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_hour = external('int64 extract_hour(int64)', devices=['CPU'])
+        extract_hour = external('int64 extract_hour(int64)')
 
         def impl(timestamp):
             return extract_hour(timestamp.time // kNanoSecsPerSec)
@@ -359,7 +359,7 @@ def heavydb_timestamp_getHours(timestamp):
 def heavydb_timestamp_getMinutes(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_minute = external('int64 extract_minute(int64)', devices=['CPU'])
+        extract_minute = external('int64 extract_minute(int64)')
 
         def impl(timestamp):
             return extract_minute(timestamp.time // kNanoSecsPerSec)
@@ -370,7 +370,7 @@ def heavydb_timestamp_getMinutes(timestamp):
 def heavydb_timestamp_getSeconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_second = external('int64 extract_second(int64)', devices=['CPU'])
+        extract_second = external('int64 extract_second(int64)')
 
         def impl(timestamp):
             return extract_second(timestamp.time // kNanoSecsPerSec)
@@ -381,7 +381,7 @@ def heavydb_timestamp_getSeconds(timestamp):
 def heavydb_timestamp_getMilliseconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_millisecond = external('int64 extract_millisecond(int64)', devices=['CPU'])
+        extract_millisecond = external('int64 extract_millisecond(int64)')
 
         def impl(timestamp):
             return extract_millisecond(
@@ -393,7 +393,7 @@ def heavydb_timestamp_getMilliseconds(timestamp):
 def heavydb_timestamp_getMicroseconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_microsecond = external('int64 extract_microsecond(int64)', devices=['CPU'])
+        extract_microsecond = external('int64 extract_microsecond(int64)')
 
         def impl(timestamp):
             return extract_microsecond(
@@ -405,7 +405,7 @@ def heavydb_timestamp_getMicroseconds(timestamp):
 def heavydb_timestamp_getNanoseconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_nanosecond = external('int64 extract_nanosecond(int64)', devices=['CPU'])
+        extract_nanosecond = external('int64 extract_nanosecond(int64)')
 
         def impl(timestamp):
             return extract_nanosecond(timestamp.time)
@@ -416,7 +416,7 @@ def heavydb_timestamp_getNanoseconds(timestamp):
 def heavydb_timestamp_truncateToYear(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_year = external('int64 datetrunc_year(int64)', devices=['CPU'])
+        datetrunc_year = external('int64 datetrunc_year(int64)')
 
         def impl(timestamp):
             timeval = datetrunc_year(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -428,7 +428,7 @@ def heavydb_timestamp_truncateToYear(timestamp):
 def heavydb_timestamp_truncateToMonth(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_month = external('int64 datetrunc_month(int64)', devices=['CPU'])
+        datetrunc_month = external('int64 datetrunc_month(int64)')
 
         def impl(timestamp):
             timeval = datetrunc_month(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -440,7 +440,7 @@ def heavydb_timestamp_truncateToMonth(timestamp):
 def heavydb_timestamp_truncateToDay(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_day = external('int64 datetrunc_day(int64)', devices=['CPU'])
+        datetrunc_day = external('int64 datetrunc_day(int64)')
 
         def impl(timestamp):
             timeval = datetrunc_day(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -452,7 +452,7 @@ def heavydb_timestamp_truncateToDay(timestamp):
 def heavydb_timestamp_truncateToHour(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_hour = external('int64 datetrunc_hour(int64)', devices=['CPU'])
+        datetrunc_hour = external('int64 datetrunc_hour(int64)')
 
         def impl(timestamp):
             timeval = datetrunc_hour(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -464,7 +464,7 @@ def heavydb_timestamp_truncateToHour(timestamp):
 def heavydb_timestamp_truncateToMinutes(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_minute = external('int64 datetrunc_minute(int64)', devices=['CPU'])
+        datetrunc_minute = external('int64 datetrunc_minute(int64)')
 
         def impl(timestamp):
             timeval = datetrunc_minute(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec

--- a/rbc/heavydb/timestamp.py
+++ b/rbc/heavydb/timestamp.py
@@ -315,7 +315,7 @@ def cast_int_to_timestamp(context, builder, fromty, toty, val):
 def heavydb_timestamp_getYear(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_year = external('int64 extract_year(int64)|cpu')
+        extract_year = external('int64 extract_year(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_year(timestamp.time // kNanoSecsPerSec)
@@ -326,7 +326,7 @@ def heavydb_timestamp_getYear(timestamp):
 def heavydb_timestamp_getMonth(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_month = external('int64 extract_month(int64)|cpu')
+        extract_month = external('int64 extract_month(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_month(timestamp.time // kNanoSecsPerSec)
@@ -337,7 +337,7 @@ def heavydb_timestamp_getMonth(timestamp):
 def heavydb_timestamp_getDay(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_day = external('int64 extract_day(int64)|cpu')
+        extract_day = external('int64 extract_day(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_day(timestamp.time // kNanoSecsPerSec)
@@ -348,7 +348,7 @@ def heavydb_timestamp_getDay(timestamp):
 def heavydb_timestamp_getHours(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_hour = external('int64 extract_hour(int64)|cpu')
+        extract_hour = external('int64 extract_hour(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_hour(timestamp.time // kNanoSecsPerSec)
@@ -359,7 +359,7 @@ def heavydb_timestamp_getHours(timestamp):
 def heavydb_timestamp_getMinutes(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_minute = external('int64 extract_minute(int64)|cpu')
+        extract_minute = external('int64 extract_minute(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_minute(timestamp.time // kNanoSecsPerSec)
@@ -370,7 +370,7 @@ def heavydb_timestamp_getMinutes(timestamp):
 def heavydb_timestamp_getSeconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_second = external('int64 extract_second(int64)|cpu')
+        extract_second = external('int64 extract_second(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_second(timestamp.time // kNanoSecsPerSec)
@@ -381,7 +381,7 @@ def heavydb_timestamp_getSeconds(timestamp):
 def heavydb_timestamp_getMilliseconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_millisecond = external('int64 extract_millisecond(int64)|cpu')
+        extract_millisecond = external('int64 extract_millisecond(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_millisecond(
@@ -393,7 +393,7 @@ def heavydb_timestamp_getMilliseconds(timestamp):
 def heavydb_timestamp_getMicroseconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_microsecond = external('int64 extract_microsecond(int64)|cpu')
+        extract_microsecond = external('int64 extract_microsecond(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_microsecond(
@@ -405,7 +405,7 @@ def heavydb_timestamp_getMicroseconds(timestamp):
 def heavydb_timestamp_getNanoseconds(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        extract_nanosecond = external('int64 extract_nanosecond(int64)|cpu')
+        extract_nanosecond = external('int64 extract_nanosecond(int64)', devices=['CPU'])
 
         def impl(timestamp):
             return extract_nanosecond(timestamp.time)
@@ -416,7 +416,7 @@ def heavydb_timestamp_getNanoseconds(timestamp):
 def heavydb_timestamp_truncateToYear(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_year = external('int64 datetrunc_year(int64)|cpu')
+        datetrunc_year = external('int64 datetrunc_year(int64)', devices=['CPU'])
 
         def impl(timestamp):
             timeval = datetrunc_year(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -428,7 +428,7 @@ def heavydb_timestamp_truncateToYear(timestamp):
 def heavydb_timestamp_truncateToMonth(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_month = external('int64 datetrunc_month(int64)|cpu')
+        datetrunc_month = external('int64 datetrunc_month(int64)', devices=['CPU'])
 
         def impl(timestamp):
             timeval = datetrunc_month(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -440,7 +440,7 @@ def heavydb_timestamp_truncateToMonth(timestamp):
 def heavydb_timestamp_truncateToDay(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_day = external('int64 datetrunc_day(int64)|cpu')
+        datetrunc_day = external('int64 datetrunc_day(int64)', devices=['CPU'])
 
         def impl(timestamp):
             timeval = datetrunc_day(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -452,7 +452,7 @@ def heavydb_timestamp_truncateToDay(timestamp):
 def heavydb_timestamp_truncateToHour(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_hour = external('int64 datetrunc_hour(int64)|cpu')
+        datetrunc_hour = external('int64 datetrunc_hour(int64)', devices=['CPU'])
 
         def impl(timestamp):
             timeval = datetrunc_hour(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec
@@ -464,7 +464,7 @@ def heavydb_timestamp_truncateToHour(timestamp):
 def heavydb_timestamp_truncateToMinutes(timestamp):
     target_info = TargetInfo()
     if target_info.is_cpu:
-        datetrunc_minute = external('int64 datetrunc_minute(int64)|cpu')
+        datetrunc_minute = external('int64 datetrunc_minute(int64)', devices=['CPU'])
 
         def impl(timestamp):
             timeval = datetrunc_minute(timestamp.time // kNanoSecsPerSec) * kNanoSecsPerSec

--- a/rbc/heavydb/year_month_time_interval.py
+++ b/rbc/heavydb/year_month_time_interval.py
@@ -173,7 +173,8 @@ def ol_day_time_interval_operator_add(a, b):
     i64_null_val = target_info.null_values["int64"]
     if target_info.is_cpu:
         DateAddHighPrecisionNullable = external(
-            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)|cpu"
+            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)",
+            devices=['CPU']
         )
 
     if isinstance(a, YearMonthTimeIntervalNumbaType) and isinstance(b, TimestampNumbaType):

--- a/rbc/heavydb/year_month_time_interval.py
+++ b/rbc/heavydb/year_month_time_interval.py
@@ -173,8 +173,7 @@ def ol_day_time_interval_operator_add(a, b):
     i64_null_val = target_info.null_values["int64"]
     if target_info.is_cpu:
         DateAddHighPrecisionNullable = external(
-            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)",
-            devices=['CPU']
+            "int64 DateAddHighPrecisionNullable(int64, int64, int64, int32, int64)"
         )
 
     if isinstance(a, YearMonthTimeIntervalNumbaType) and isinstance(b, TimestampNumbaType):

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -769,7 +769,6 @@ class RemoteJIT:
 
         or any other object that can be converted to function type,
         see `Type.fromobject` for more information.
-
         """
         if local:
             s = Signature(self.local)
@@ -908,7 +907,7 @@ class RemoteJIT:
         ----------
         ftype: Type
           typesystem type of a function
-        device: {"CPU", "CPU"}
+        device: {"CPU", "GPU"}
           specified device
         """
         return True

--- a/rbc/targetinfo.py
+++ b/rbc/targetinfo.py
@@ -99,6 +99,7 @@ class TargetInfo(object):
         self.type_sizeof = {}
         self._supported_libraries = set()  # libfuncs.Library instances
         self._userdefined_externals = set()
+        self._compile_target = None
 
     def __repr__(self):
         return f'{self.__class__.__name__}(name={self.name!r})'
@@ -114,6 +115,19 @@ class TargetInfo(object):
         else:
             raise TypeError(
                 f'Expected libfuncs.Library instance or library name but got {type(lib)}')
+
+    def set_compile_target(self, target_name):
+        """Set target function name being compiled.
+        """
+        assert target_name is None or self._compile_target is None,\
+            (target_name, self._compile_target)
+        self._compile_target = target_name
+
+    def get_compile_target(self):
+        """Return target function name being compiled.
+        """
+        assert self._compile_target is not None
+        return self._compile_target
 
     def supports(self, name):
         """Return True if the target system defines symbol name.

--- a/rbc/tests/heavydb/test_array.py
+++ b/rbc/tests/heavydb/test_array.py
@@ -90,8 +90,8 @@ extern "C" {{
 #endif
     '''
     heavydb.user_defined_llvm_ir[device] = heavydb.compiler(c_code)
-    mysum_impl = external(f'{ctype} mysum_impl({ctype}*, int32_t)')
-    myval_impl = external(f'{ctype} myval_impl({ctype}*)')
+    mysum_impl = external(f'{ctype} mysum_impl({ctype}*, int32_t)', devices=[device])
+    myval_impl = external(f'{ctype} myval_impl({ctype}*)', devices=[device])
 
     @heavydb(f'{ctype}({ctype}[])', devices=[device])
     def mysum_ptr(x):
@@ -281,7 +281,7 @@ def test_array_setitem(heavydb):
 def test_array_constructor_noreturn(heavydb):
     heavydb.reset()
 
-    @heavydb('float64(int32)')
+    @heavydb('float64(int32)', devices=['CPU'])
     def array_noreturn(size):
         a = Array(size, nb_types.float64)
         b = Array(size, nb_types.float64)
@@ -328,7 +328,7 @@ def test_array_constructor_return(heavydb):
 def test_array_constructor_len(heavydb):
     heavydb.reset()
 
-    @heavydb('int64(int32)')
+    @heavydb('int64(int32)', devices=['CPU'])
     def array_len(size):
         a = Array(size, nb_types.float64)
         return len(a)
@@ -342,7 +342,7 @@ def test_array_constructor_len(heavydb):
 def test_array_constructor_getitem(heavydb):
     heavydb.reset()
 
-    @heavydb('double(int32, int32)')
+    @heavydb('double(int32, int32)', devices=['CPU'])
     def array_ptr(size, pos):
         a = Array(size, np.double)
         for i in range(size):
@@ -358,7 +358,7 @@ def test_array_constructor_getitem(heavydb):
 def test_array_constructor_is_null(heavydb):
     heavydb.reset()
 
-    @heavydb('int8(int64)')
+    @heavydb('int8(int64)', devices=['CPU'])
     def array_is_null(size):
         a = Array(size, 'double')
         return a.is_null()

--- a/rbc/tests/heavydb/test_array_methods.py
+++ b/rbc/tests/heavydb/test_array_methods.py
@@ -57,7 +57,7 @@ def define(heavydb):
         a.fill(v)
         return a
 
-    @heavydb('double(int64, double)')
+    @heavydb('double(int64, double)', devices=['CPU'])
     def ndarray_max(size, v):
         a = Array(size, 'double')
         a.fill(v)
@@ -72,29 +72,29 @@ def define(heavydb):
             exec(fn)
             fn = locals()[fn_name]
             if op == 'mean':
-                heavydb('float64(int32)')(fn)
+                heavydb('float64(int32)', devices=['CPU'])(fn)
             else:
-                heavydb(f'{retty}(int32)')(fn)
+                heavydb(f'{retty}(int32)', devices=['CPU'])(fn)
 
-    @heavydb('double(int64, double)')
+    @heavydb('double(int64, double)', devices=['CPU'])
     def ndarray_mean(size, v):
         a = Array(size, 'double')
         a.fill(v)
         return a.mean()
 
-    @heavydb('double(int64, double)')
+    @heavydb('double(int64, double)', devices=['CPU'])
     def ndarray_min(size, v):
         a = Array(size, 'double')
         a.fill(v)
         return a.min()
 
-    @heavydb('double(int64, double)')
+    @heavydb('double(int64, double)', devices=['CPU'])
     def ndarray_sum(size, v):
         a = Array(size, 'double')
         a.fill(v)
         return a.sum()
 
-    @heavydb('double(int64, double)')
+    @heavydb('double(int64, double)', devices=['CPU'])
     def ndarray_prod(size, v):
         a = Array(size, 'double')
         a.fill(v)

--- a/rbc/tests/heavydb/test_array_operators.py
+++ b/rbc/tests/heavydb/test_array_operators.py
@@ -100,7 +100,7 @@ def define(heavydb):
             b[i] = nb_types.int32(size-i-1)
         return operator.and_(a, b)
 
-    @heavydb('int64(int64, int64, int64)')
+    @heavydb('int64(int64, int64, int64)', devices=['CPU'])
     def operator_countOf(size, fill_value, b):
         a = Array(size, 'int64')
         for i in range(size):
@@ -114,7 +114,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return a == v
 
-    @heavydb('bool(int64, int32)')
+    @heavydb('bool(int64, int32)', devices=['CPU'])
     def operator_eq_array(size, v):
         a = Array(size, 'int32')
         for i in range(size):
@@ -146,7 +146,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return a >= v
 
-    @heavydb('bool(int64, int32)')
+    @heavydb('bool(int64, int32)', devices=['CPU'])
     def operator_ge_array(size, v):
         a = Array(size, 'int32')
         for i in range(size):
@@ -160,7 +160,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return a > v
 
-    @heavydb('bool(int64, int32)')
+    @heavydb('bool(int64, int32)', devices=['CPU'])
     def operator_gt_array(size, v):
         a = Array(size, 'int32')
         for i in range(size):
@@ -307,26 +307,26 @@ def define(heavydb):
         operator.ixor(a, b)
         return a
 
-    @heavydb('int8(int64, int32)')
+    @heavydb('int8(int64, int32)', devices=['CPU'])
     def operator_in(size, v):
         a = Array(size, 'int32')
         for i in range(size):
             a[i] = nb_types.int32(i)
         return v in a
 
-    @heavydb('int8(int64, int32)')
+    @heavydb('int8(int64, int32)', devices=['CPU'])
     def operator_is(size, v):
         a = Array(size, 'int32')
         a.fill(v)
         return a is a
 
-    @heavydb('int8(int64, int32)')
+    @heavydb('int8(int64, int32)', devices=['CPU'])
     def operator_is_not(size, v):
         a = Array(size, 'int32')
         a.fill(v)
         return a is not a
 
-    @heavydb('int8(int64, int32)')
+    @heavydb('int8(int64, int32)', devices=['CPU'])
     def operator_is_not2(size, v):
         a = Array(size, 'int32')
         a.fill(v)
@@ -341,7 +341,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return a <= v
 
-    @heavydb('bool(int64, int32)')
+    @heavydb('bool(int64, int32)', devices=['CPU'])
     def operator_le_array(size, v):
         a = Array(size, 'int32')
         for i in range(size):
@@ -364,7 +364,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return a < v
 
-    @heavydb('bool(int64, int32)')
+    @heavydb('bool(int64, int32)', devices=['CPU'])
     def operator_lt_array(size, v):
         a = Array(size, 'int32')
         for i in range(size):
@@ -396,7 +396,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return a != v
 
-    @heavydb('bool(int64, int32)')
+    @heavydb('bool(int64, int32)', devices=['CPU'])
     def operator_ne_array(size, v):
         a = Array(size, 'int32')
         for i in range(size):
@@ -410,7 +410,7 @@ def define(heavydb):
             a[i] = nb_types.int32(i)
         return operator.neg(a)
 
-    @heavydb('int8(int64, int32)')
+    @heavydb('int8(int64, int32)', devices=['CPU'])
     def operator_not_in(size, v):
         a = Array(size, 'int32')
         for i in range(size):

--- a/rbc/tests/heavydb/test_black_scholes.py
+++ b/rbc/tests/heavydb/test_black_scholes.py
@@ -78,7 +78,7 @@ def test_black_scholes_udf(heavydb):
     # queries:
     heavydb.register()
 
-    @heavydb('double(double, double, double, double, double)')
+    @heavydb('double(double, double, double, double, double)', devices=['CPU'])
     def black_scholes_UDF(S, X, T, r, sigma):
         d1 = (np.log(S/X) + (r + 0.5 * sigma**2)*T) / (sigma * np.sqrt(T))
         d2 = d1 - sigma * np.sqrt(T)
@@ -111,7 +111,7 @@ def test_black_scholes_udtf(heavydb):
     heavydb.register()
 
     @heavydb('int32(Column<double>, Column<double>, Column<double>, Column<double>, Column<double>,'  # noqa: E501
-             ' RowMultiplier, OutputColumn<double>)')
+             ' RowMultiplier, OutputColumn<double>)', devices=['CPU'])
     def black_scholes_udtf(S, X, T, r, sigma, m, out):
         input_row_count = len(X)
 

--- a/rbc/tests/heavydb/test_caller.py
+++ b/rbc/tests/heavydb/test_caller.py
@@ -70,10 +70,10 @@ def test_udtf_string_repr(heavydb):
 
     assert_equal(repr(arange),
                  ("RemoteDispatcher('arange', ['UDTF(int32 size, T x0, OutputColumn<T> x),"
-                  " T=int64|float64|int32, device=cpu'])"))
+                  " T=int64|float64|int32, device=CPU'])"))
     assert_equal(str(arange),
                  ("arange['UDTF(int32 size, T x0, OutputColumn<T> x),"
-                  " T=int64|float64|int32, device=cpu']"))
+                  " T=int64|float64|int32, device=CPU']"))
 
     assert_equal(repr(arange(5, 0)),
                  ("HeavyDBQueryCapsule('SELECT x FROM"

--- a/rbc/tests/heavydb/test_caller.py
+++ b/rbc/tests/heavydb/test_caller.py
@@ -37,7 +37,7 @@ def define(heavydb):
             y[i] = x[i] + dx
         return size
 
-    @heavydb('TextEncodingNone(TextEncodingNone)')
+    @heavydb('TextEncodingNone(TextEncodingNone)', devices=['CPU'])
     def myupper(s):
         r = TextEncodingNone(len(s))
         for i in range(len(s)):
@@ -114,7 +114,7 @@ def test_remote_float64_evaluation(heavydb):
 
 def test_remote_TextEncodingNone_evaluation(heavydb):
     myupper = heavydb.get_caller('myupper')
-    assert str(myupper) == "myupper['TextEncodingNone(TextEncodingNone)']"
+    assert str(myupper) == "myupper['TextEncodingNone(TextEncodingNone), device=CPU']"
     assert str(myupper("abc")) == "SELECT myupper('abc')"
     assert str(myupper("abc").execute()) == 'ABC'
     assert str(myupper(b"abc")) == "SELECT myupper('abc')"

--- a/rbc/tests/heavydb/test_column_basic.py
+++ b/rbc/tests/heavydb/test_column_basic.py
@@ -856,7 +856,7 @@ def test_column_dtype(heavydb):
 def test_column_enumerate(heavydb):
     from rbc.externals.heavydb import set_output_row_size
 
-    @heavydb('int32(Column<int32>, OutputColumn<int32>)')
+    @heavydb('int32(Column<int32>, OutputColumn<int32>)', devices=['CPU'])
     def col_enumerate(x, y):
         sz = len(x)
         set_output_row_size(sz)

--- a/rbc/tests/heavydb/test_external.py
+++ b/rbc/tests/heavydb/test_external.py
@@ -36,8 +36,8 @@ def test_unnamed_external(heavydb):
 
 def test_replace_declaration(heavydb):
 
-    _ = external("f64 fma(f64)|CPU")
-    fma = external("f64 fma(f64, f64, f64)|CPU")
+    _ = external("f64 fma(f64)", devices=['CPU'])
+    fma = external("f64 fma(f64, f64, f64)", devices=['CPU'])
 
     @heavydb("double(double, double, double)", devices=["cpu"])
     def test_fma(a, b, c):
@@ -50,7 +50,7 @@ def test_replace_declaration(heavydb):
 
 def test_require_target_info(heavydb):
 
-    log2 = external("double log2(double)|CPU")
+    log2 = external("double log2(double)", devices=['CPU'])
 
     @heavydb("double(double)", devices=["cpu"])
     def test_log2(a):

--- a/rbc/tests/heavydb/test_external.py
+++ b/rbc/tests/heavydb/test_external.py
@@ -36,8 +36,8 @@ def test_unnamed_external(heavydb):
 
 def test_replace_declaration(heavydb):
 
-    _ = external("f64 fma(f64)", devices=['CPU'])
-    fma = external("f64 fma(f64, f64, f64)", devices=['CPU'])
+    _ = external("f64 fma(f64)")
+    fma = external("f64 fma(f64, f64, f64)")
 
     @heavydb("double(double, double, double)", devices=["cpu"])
     def test_fma(a, b, c):
@@ -50,7 +50,7 @@ def test_replace_declaration(heavydb):
 
 def test_require_target_info(heavydb):
 
-    log2 = external("double log2(double)", devices=['CPU'])
+    log2 = external("double log2(double)")
 
     @heavydb("double(double)", devices=["cpu"])
     def test_log2(a):

--- a/rbc/tests/heavydb/test_nrt_string.py
+++ b/rbc/tests/heavydb/test_nrt_string.py
@@ -50,7 +50,7 @@ def define(heavydb):
             r = ''
         return TextEncodingNone(r)
 
-    @heavydb('bool(TextEncodingNone, TextEncodingNone, TextEncodingNone)')
+    @heavydb('bool(TextEncodingNone, TextEncodingNone, TextEncodingNone)', devices=['CPU'])
     def test_endswith(method, t, value):
         s = t.to_string()
         w = value.to_string()
@@ -102,7 +102,7 @@ def define(heavydb):
             r = s.zfill(width)
         return TextEncodingNone(r)
 
-    @heavydb('i32(TextEncodingNone, TextEncodingNone, TextEncodingNone)')
+    @heavydb('i32(TextEncodingNone, TextEncodingNone, TextEncodingNone)', devices=['CPU'])
     def test_string2(method, t, word):
         s = t.to_string()
         w = word.to_string()
@@ -118,7 +118,7 @@ def define(heavydb):
             return s.rindex(w)
         return -1
 
-    @heavydb('bool(TextEncodingNone, TextEncodingNone)')
+    @heavydb('bool(TextEncodingNone, TextEncodingNone)', devices=['CPU'])
     def test_is(method, t):
         s = t.to_string()
         if method == 'isalnum':

--- a/rbc/tests/heavydb/test_text_encoding_dict.py
+++ b/rbc/tests/heavydb/test_text_encoding_dict.py
@@ -37,7 +37,7 @@ def define(heavydb):
         return m * sz
 
     @heavydb("int32(ColumnList<TextEncodingDict>, RowMultiplier, OutputColumn<int32_t>)",
-             devices=['cpu'])
+             devices=['CPU'])
     def test_copy_column_list(lst, m, y):
         for j in range(len(y)):
             y[j] = 0
@@ -52,7 +52,7 @@ def define(heavydb):
              "OutputColumn<T> | input_id=args<0, 2>, "
              "OutputColumn<T> | input_id=args<2, 0>, "
              "OutputColumn<T> | input_id=args<2, 1>)",
-             devices=['cpu'], T=["TextEncodingDict"])
+             devices=['CPU'], T=["TextEncodingDict"])
     def test_copy_column_list2(lst1, col, lst2, m, a, b, c):
         for j in range(lst1.nrows):
             a[j] = lst1[2][j]
@@ -61,7 +61,7 @@ def define(heavydb):
         return lst1.nrows
 
     @heavydb("int32(ColumnList<T>, Column<U>, RowMultiplier, OutputColumn<U> | input_id=args<1>)",
-             devices=['cpu'], T=["int32_t"], U=["TextEncodingDict"])
+             devices=['CPU'], T=["int32_t"], U=["TextEncodingDict"])
     def test_copy_column_list3(lst, col, m, y):
         sz = len(col)
         for j in range(sz):
@@ -69,13 +69,13 @@ def define(heavydb):
         return m * sz
 
     if heavydb.version[:2] >= (6, 2):
-        @heavydb('int32(Column<TextEncodingDict>, RowMultiplier, TextEncodingNone, OutputColumn<int32_t>)',  # noqa: E501
-                 devices=['cpu'])
+        @heavydb('int32(Column<TextEncodingDict>, RowMultiplier, TextEncodingNone, OutputColumn<int32_t>)', devices=['CPU'])  # noqa: E501
         def test_getstringid_from_arg(x, m, text, y):
             y[0] = x.string_dict_proxy.getStringId(text)
             return 1
 
-        # Using TableFunctionManager argument implies devices=['cpu']
+        # No need to specify devices=['CPU'] when a UDTF uses
+        # TableFunctionManager argument.
         @heavydb('int32(TableFunctionManager, OutputColumn<TextEncodingDict> | input_id=args<>)')  # noqa: E501
         def test_empty_input_id(mgr, out):
             mgr.set_output_row_size(2)
@@ -83,20 +83,21 @@ def define(heavydb):
             out[1] = out.string_dict_proxy.getStringId("mlpack")
             return len(out)
 
-        @heavydb('int32(Column<T>, RowMultiplier, OutputColumn<int32_t>)|CPU',
-                 T=['TextEncodingDict'])
+        @heavydb('int32(Column<T>, RowMultiplier, OutputColumn<int32_t>)',
+                 T=['TextEncodingDict'],
+                 devices=['CPU'])
         def test_getstringid_from_unicode(x, m, y):
             text = "foo"  # this creates a unicode string
             y[0] = x.string_dict_proxy.getStringId(text)
             return 1
 
-        @heavydb('int32(Column<TextEncodingDict>, ConstantParameter, OutputColumn<int32_t>) | CPU')  # noqa: E501
+        @heavydb('int32(Column<TextEncodingDict>, ConstantParameter, OutputColumn<int32_t>)', devices=['CPU'])  # noqa: E501
         def test_getstring(x, unique, y):
             for i in range(unique):
                 y[i] = len(x.string_dict_proxy.getString(i))
             return unique
 
-        @heavydb('int32(ColumnList<TextEncodingDict>, int32_t, RowMultiplier, OutputColumn<int32_t>) | CPU')  # noqa: E501
+        @heavydb('int32(ColumnList<TextEncodingDict>, int32_t, RowMultiplier, OutputColumn<int32_t>)', devices=['CPU'])  # noqa: E501
         def test_getstring_lst(lst, unique, m, y):
             for i in range(lst.nrows):
                 y[i] = 0
@@ -108,7 +109,8 @@ def define(heavydb):
             return unique
 
     if heavydb.version[:2] >= (6, 3):
-        # Using RowFunctionManager argument implies devices=['cpu']
+        # No need to specify devices=['CPU'] when a UDF uses
+        # RowFunctionManager argument.
         @heavydb('TextEncodingDict(RowFunctionManager, TextEncodingDict)')
         def fn_copy(mgr, t):
             db_id = mgr.getDictDbId('fn_copy', 0)

--- a/rbc/tests/heavydb/test_text_encoding_dict.py
+++ b/rbc/tests/heavydb/test_text_encoding_dict.py
@@ -75,28 +75,28 @@ def define(heavydb):
             y[0] = x.string_dict_proxy.getStringId(text)
             return 1
 
-        @heavydb('int32(TableFunctionManager, OutputColumn<TextEncodingDict> | input_id=args<>)',  # noqa: E501
-                 devices=['cpu'])
+        # Using TableFunctionManager argument implies devices=['cpu']
+        @heavydb('int32(TableFunctionManager, OutputColumn<TextEncodingDict> | input_id=args<>)')  # noqa: E501
         def test_empty_input_id(mgr, out):
             mgr.set_output_row_size(2)
             out[0] = out.string_dict_proxy.getStringId("onedal")
             out[1] = out.string_dict_proxy.getStringId("mlpack")
             return len(out)
 
-        @heavydb('int32(Column<T>, RowMultiplier, OutputColumn<int32_t>)',
-                 devices=['cpu'], T=['TextEncodingDict'])
+        @heavydb('int32(Column<T>, RowMultiplier, OutputColumn<int32_t>)|CPU',
+                 T=['TextEncodingDict'])
         def test_getstringid_from_unicode(x, m, y):
             text = "foo"  # this creates a unicode string
             y[0] = x.string_dict_proxy.getStringId(text)
             return 1
 
-        @heavydb('int32(Column<TextEncodingDict>, ConstantParameter, OutputColumn<int32_t>)')  # noqa: E501
+        @heavydb('int32(Column<TextEncodingDict>, ConstantParameter, OutputColumn<int32_t>) | CPU')  # noqa: E501
         def test_getstring(x, unique, y):
             for i in range(unique):
                 y[i] = len(x.string_dict_proxy.getString(i))
             return unique
 
-        @heavydb('int32(ColumnList<TextEncodingDict>, int32_t, RowMultiplier, OutputColumn<int32_t>)')  # noqa: E501
+        @heavydb('int32(ColumnList<TextEncodingDict>, int32_t, RowMultiplier, OutputColumn<int32_t>) | CPU')  # noqa: E501
         def test_getstring_lst(lst, unique, m, y):
             for i in range(lst.nrows):
                 y[i] = 0
@@ -108,21 +108,22 @@ def define(heavydb):
             return unique
 
     if heavydb.version[:2] >= (6, 3):
-        @heavydb('TextEncodingDict(RowFunctionManager, TextEncodingDict)', devices=['cpu'])
+        # Using RowFunctionManager argument implies devices=['cpu']
+        @heavydb('TextEncodingDict(RowFunctionManager, TextEncodingDict)')
         def fn_copy(mgr, t):
             db_id = mgr.getDictDbId('fn_copy', 0)
             dict_id = mgr.getDictId('fn_copy', 0)
             str = mgr.getString(db_id, dict_id, t)
             return mgr.getOrAddTransient(mgr.TRANSIENT_DICT_DB_ID, mgr.TRANSIENT_DICT_ID, str)
 
-        @heavydb('TextEncodingNone(RowFunctionManager, TextEncodingDict)', devices=['cpu'])
+        @heavydb('TextEncodingNone(RowFunctionManager, TextEncodingDict)')
         def to_text_encoding_none_1(mgr, t):
             db_id = mgr.getDictDbId('to_text_encoding_none_1', 0)
             dict_id = mgr.getDictId('to_text_encoding_none_1', 0)
             str = mgr.getString(db_id, dict_id, t)
             return str
 
-        @heavydb('TextEncodingNone(RowFunctionManager, TextEncodingDict)', devices=['cpu'])
+        @heavydb('TextEncodingNone(RowFunctionManager, TextEncodingDict)')
         def to_text_encoding_none_2(mgr, t):
             db_id = mgr.getDictDbId('to_text_encoding_none_2', 0)
             dict_id = mgr.getDictId('to_text_encoding_none_2', 0)

--- a/rbc/tests/heavydb/test_text_encoding_none.py
+++ b/rbc/tests/heavydb/test_text_encoding_none.py
@@ -121,7 +121,7 @@ def test_TextEncodingNone_eq(heavydb):
     def eq1(a, b):
         return a == b
 
-    @heavydb('int32(TextEncodingNone)')
+    @heavydb('int32(TextEncodingNone)', devices=['CPU'])
     def eq2(a):
         return a == 'world'
 
@@ -142,7 +142,7 @@ def test_TextEncodingNone_ne(heavydb):
     def ne1(a, b):
         return a != b
 
-    @heavydb('int32(TextEncodingNone)')
+    @heavydb('int32(TextEncodingNone)', devices=['CPU'])
     def ne2(a):
         return a != 'world'
 

--- a/rbc/tests/heavydb/test_udtf.py
+++ b/rbc/tests/heavydb/test_udtf.py
@@ -234,7 +234,7 @@ def test_table_function_error(heavydb):
     heavydb.require_version((5, 8), 'Requires heavydb-internal PR 5879')
     heavydb.reset()
 
-    @heavydb('int32(Column<double>, double, RowMultiplier, OutputColumn<double>)')
+    @heavydb('int32(Column<double>, double, RowMultiplier, OutputColumn<double>)', devices=['CPU'])
     def my_divide(column, k, row_multiplier, out):
         if k == 0:
             return table_function_error('division by zero')

--- a/rbc/tests/test_remotejit.py
+++ b/rbc/tests/test_remotejit.py
@@ -49,10 +49,10 @@ def test_devices_validation(ljit):
 
     # failing cases
 
-    with pytest.raises(ValueError, match="'devices' can only be a list"):
+    with pytest.raises(ValueError, match="expected a device to be CPU or GPU, got `both`"):
         _ = ljit('double(double, double)', devices=['both'])
 
-    with pytest.raises(ValueError, match="'devices' can only be a list"):
+    with pytest.raises(ValueError, match="expected a device to be CPU or GPU, got `bob`"):
         _ = ljit('double(double, double)', devices=['cpu', 'gpu', 'bob'])
 
 

--- a/rbc/utils.py
+++ b/rbc/utils.py
@@ -237,5 +237,28 @@ def check_returns_none(func):
     return True
 
 
+def validate_devices(devices):
+    """Return valid devices list from a user-specified devices container.
+
+    A valid device is "CPU" or "GPU" but users can specify, say, lower
+    case variants of these.
+    """
+    if devices is None:
+        return devices
+    if not isinstance(devices, (list, set, tuple)):
+        raise TypeError(f'expected devices to be a list, got {type(devices)}')
+    valid_devices = []
+    for d_ in devices:
+        if not isinstance(d_, str):
+            raise TypeError(f'expected a device to be a string, got {type(d_)}')
+        # normalize
+        d = d_.upper()
+        if d not in {'CPU', 'GPU'}:
+            raise ValueError(f'expected a device to be CPU or GPU, got `{d_}`')
+        if d not in valid_devices:
+            valid_devices.append(d)
+    return valid_devices
+
+
 DEFAULT = object()
 UNSPECIFIED = object()


### PR DESCRIPTION
Fixes #541 .

In addition:
- fixes numerous warnings from tests when using cuda-enabled heavydb server
- auto-detect the devices support from signature types
- introduce `devices` kw argument to `external`
- deprecate CPU/GPU annotations