### PR TITLE
Cache the NRT module and introduce rbc.config to keep track of env vars

### DIFF
--- a/doc/envvars.rst
+++ b/doc/envvars.rst
@@ -13,4 +13,9 @@ Debugging
 .. envvar:: RBC_DEBUG_NRT
 
     If set to non-zero, insert debug statements to our implementation
-    of Numba Runtime (NRT)
+    of Numba Runtime (NRT).
+
+.. envvar:: RBC_ENABLE_NRT
+
+    If set to 0, globally disable inserting the Numba Runtime (NRT) module.
+    Default is 1.

--- a/rbc/config.py
+++ b/rbc/config.py
@@ -1,0 +1,6 @@
+import os
+
+
+DEBUG = int(os.environ.get("RBC_DEBUG", False))
+DEBUG_NRT = int(os.environ.get("RBC_DEBUG_NRT", False))
+ENABLE_NRT = int(os.environ.get("RBC_ENABLE_NRT", True))

--- a/rbc/remotejit.py
+++ b/rbc/remotejit.py
@@ -8,7 +8,7 @@ import inspect
 import warnings
 import ctypes
 from collections import defaultdict
-from . import irtools
+from . import irtools, config
 from .errors import UnsupportedError
 from .typesystem import Type, get_signature
 from .thrift import Server, Dispatcher, dispatchermethod, Data, Client
@@ -587,7 +587,7 @@ class RemoteJIT:
         if host == 'localhost':
             host = get_local_ip()
 
-        if int(os.environ.get('RBC_DEBUG', False)):
+        if config.DEBUG:
             self.debug = True
         else:
             self.debug = debug

--- a/rbc/tests/__init__.py
+++ b/rbc/tests/__init__.py
@@ -1,14 +1,32 @@
 __all__ = ['heavydb_fixture', 'sql_execute']
 
 
-from abc import abstractproperty
-import numpy as np
+import contextlib
 import os
-import pytest
 import warnings
-import numpy
+from abc import abstractproperty
 
+import numpy
+import numpy as np
+import pytest
 from packaging.version import Version
+
+from rbc import config
+
+
+@contextlib.contextmanager
+def override_config(name, value):
+    """
+    Return a context manager that temporarily sets RBC config variable
+    *name* to *value*.  *name* must be the name of an existing variable
+    in rbc.config.
+    """
+    old_value = getattr(config, name)
+    setattr(config, name, value)
+    try:
+        yield
+    finally:
+        setattr(config, name, old_value)
 
 
 def assert_equal(actual, desired):

--- a/rbc/tests/heavydb/test_nrt.py
+++ b/rbc/tests/heavydb/test_nrt.py
@@ -1,0 +1,22 @@
+import pytest
+
+from rbc.tests import heavydb_fixture, override_config
+
+
+@pytest.fixture(scope='module')
+def heavydb():
+    for o in heavydb_fixture(globals(), load_test_data=False):
+        yield o
+
+
+def test_nrt_warning(heavydb):
+
+    @heavydb("i32(i32)", devices=['cpu'])
+    def list_append(t):
+        lst = list()
+        lst.append('abc')
+        return len(lst)
+
+    with override_config('ENABLE_NRT', 0):
+        with pytest.warns(UserWarning, match='NRT required but not enabled'):
+            heavydb.register()


### PR DESCRIPTION
As title. This PR enables caching the NRT module, instead of regenerating it each time an UD[T]F is compiled. It also creates a `rbc/config.py` file to manage environment variables.