### PR TITLE
Reduce compile-time

### DIFF
--- a/rbc/heavydb/pipeline.py
+++ b/rbc/heavydb/pipeline.py
@@ -1,14 +1,9 @@
-import operator
-
-from rbc.errors import NumbaTypeError
-from numba.core import ir, types
+from numba.core import ir
 from numba.core.compiler import CompilerBase, DefaultPassBuilder
 from numba.core.compiler_machinery import FunctionPass, register_pass
-from numba.core.untyped_passes import (IRProcessing,
-                                       RewriteSemanticConstants,
-                                       ReconstructSSA,
-                                       DeadBranchPrune,)
-from numba.core.typed_passes import PartialTypeInference, DeadCodeElimination
+from numba.core.untyped_passes import IRProcessing
+
+from rbc.errors import NumbaTypeError
 
 
 @register_pass(mutates_CFG=False, analysis_only=False)
@@ -30,68 +25,6 @@ class CheckRaiseStmts(FunctionPass):
         return False
 
 
-@register_pass(mutates_CFG=False, analysis_only=False)
-class DTypeComparison(FunctionPass):
-    _name = "DTypeComparison"
-
-    def __init__(self):
-        FunctionPass.__init__(self)
-
-    def is_dtype_comparison(self, func_ir, binop):
-        """ Return True if binop is a dtype comparison
-        """
-        def is_getattr(expr):
-            return isinstance(expr, ir.Expr) and expr.op == 'getattr'
-
-        if binop.fn != operator.eq:
-            return False
-
-        lhs = func_ir.get_definition(binop.lhs.name)
-        rhs = func_ir.get_definition(binop.lhs.name)
-
-        return (is_getattr(lhs) and lhs.attr == 'dtype') or \
-               (is_getattr(rhs) and rhs.attr == 'dtype')
-
-    def run_pass(self, state):
-        # run as subpipeline
-        from numba.core.compiler_machinery import PassManager
-        pm = PassManager("subpipeline")
-        pm.add_pass(PartialTypeInference, "performs partial type inference")
-        pm.finalize()
-        pm.run(state)
-
-        mutated = False
-
-        func_ir = state.func_ir
-        for block in func_ir.blocks.values():
-            for assign in block.find_insts(ir.Assign):
-                binop = assign.value
-                if not (isinstance(binop, ir.Expr) and binop.op == 'binop'):
-                    continue
-                if self.is_dtype_comparison(func_ir, binop):
-                    var = func_ir.get_assignee(binop)
-                    typ = state.typemap.get(var.name, None)
-                    if isinstance(typ, types.BooleanLiteral):
-                        loc = binop.loc
-                        rhs = ir.Const(typ.literal_value, loc)
-                        new_assign = ir.Assign(rhs, var, loc)
-
-                        # replace instruction
-                        block.insert_after(new_assign, assign)
-                        block.remove(assign)
-                        mutated = True
-
-        if mutated:
-            pm = PassManager("subpipeline")
-            # rewrite consts / dead branch pruning
-            pm.add_pass(DeadCodeElimination, "dead code elimination")
-            pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
-            pm.add_pass(DeadBranchPrune, "dead branch pruning")
-            pm.finalize()
-            pm.run(state)
-        return mutated
-
-
 class HeavyDBCompilerPipeline(CompilerBase):
     def define_pipelines(self):
         # define a new set of pipelines (just one in this case) and for ease
@@ -100,7 +33,6 @@ class HeavyDBCompilerPipeline(CompilerBase):
         pm = DefaultPassBuilder.define_nopython_pipeline(self.state)
         # Add the new pass to run after IRProcessing
         pm.add_pass_after(CheckRaiseStmts, IRProcessing)
-        pm.add_pass_after(DTypeComparison, ReconstructSSA)
         # finalize
         pm.finalize()
         # return as an iterable, any number of pipelines may be defined!

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -72,7 +72,6 @@ def get_called_functions(library,
     for lib in library._linking_libraries:
         result['libraries'].add(lib)
         for df in lib.get_defined_functions():
-            # q.append(df.name)
             linked_functions[df.name] = lib
 
     while len(q) > 0:
@@ -113,70 +112,13 @@ def get_called_functions(library,
                             lib = linked_functions.get(name)
                             result['defined'].add(name)
                             result['libraries'].add(lib)
-                            # q.append(name)
+                            q.append(name)
                             break
                         else:
                             result['declarations'].add(name)
                     else:
                         q.append(name)
     return result
-
-
-# def get_called_functions(library, funcname=None, debug=False):
-#     result = defaultdict(set)
-#     module = library._final_module
-#     if funcname is None:
-#         for df in library.get_defined_functions():
-#             for k, v in get_called_functions(library, df.name, debug).items():
-#                 result[k].update(v)
-#         return result
-
-#     func = module.get_function(funcname)
-#     assert func.name == funcname, (func.name, funcname)
-#     result['defined'].add(funcname)
-#     for block in func.blocks:
-#         for instruction in block.instructions:
-#             if instruction.opcode == 'call':
-#                 instr = list(instruction.operands)[-1]
-#                 name = instr.name
-#                 try:
-#                     f = module.get_function(name)
-#                 except NameError:
-#                     if 'bitcast' not in str(instr):
-#                         raise  # re-raise
-
-#                     # attempt to find caller symbol in instr
-#                     name = find_at_word(str(instr))
-#                     if name is None:
-#                         # ignore call to function pointer
-#                         msg = f'Ignoring call to bitcast instruction:\n{instr}'
-#                         if debug:
-#                             warnings.warn(msg)
-#                         continue
-#                     f = module.get_function(name)
-
-#                 if name.startswith('llvm.'):
-#                     result['intrinsics'].add(name)
-#                 elif f.is_declaration:
-#                     found = False
-#                     for lib in library._linking_libraries:
-#                         for df in lib.get_defined_functions():
-#                             if name == df.name:
-#                                 result['defined'].add(name)
-#                                 result['libraries'].add(lib)
-#                                 found = True
-#                                 for k, v in get_called_functions(lib, name, debug).items():
-#                                     result[k].update(v)
-#                                 break
-#                         if found:
-#                             break
-#                     if not found:
-#                         result['declarations'].add(name)
-#                 else:
-#                     result['defined'].add(name)
-#                     for k, v in get_called_functions(library, name, debug).items():
-#                         result[k].update(v)
-#     return result
 
 
 # ---------------------------------------------------------------------------

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -68,6 +68,11 @@ def get_called_functions(library,
     else:
         q.append(funcname)
 
+    linked_functions: Dict[str, JITRemoteCodeLibrary] = dict()
+    for lib in library._linking_libraries:
+        for df in lib.get_defined_functions():
+            linked_functions[df.name] = lib
+
     while len(q) > 0:
         funcname = q.pop()
 
@@ -103,18 +108,26 @@ def get_called_functions(library,
                         result['intrinsics'].add(name)
                     elif f.is_declaration:
                         found = False
-                        for lib in library._linking_libraries:
-                            for df in lib.get_defined_functions():
-                                if name == df.name:
-                                    result['defined'].add(name)
-                                    result['libraries'].add(lib)
-                                    found = True
-                                    q.append(name)
-                                    break
-                            if found:
-                                break
-                        if not found:
+                        if name in linked_functions:
+                            lib = linked_functions.get(name)
+                            result['defined'].add(name)
+                            result['libraries'].add(lib)
+                            q.append(name)
+                            break
+                        else:
                             result['declarations'].add(name)
+                        # for lib in library._linking_libraries:
+                        #     for df in lib.get_defined_functions():
+                        #         if name == df.name:
+                        #             result['defined'].add(name)
+                        #             result['libraries'].add(lib)
+                        #             found = True
+                        #             q.append(name)
+                        #             break
+                        #     if found:
+                        #         break
+                        # if not found:
+                        #     result['declarations'].add(name)
                     else:
                         result['defined'].add(name)
                         q.append(name)

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Optional
+from typing import Optional, Dict, Set
 
 import llvmlite.binding as llvm
 from llvmlite import ir
@@ -55,7 +55,7 @@ def find_at_word(text: str) -> Optional[str]:
     return word[1:]
 
 
-def get_called_functions(result: dict[str, set[str]],
+def get_called_functions(result: Dict[str, Set[str]],
                          library,
                          funcname: Optional[str] = None,
                          debug: bool = False) -> None:

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -115,18 +115,6 @@ def get_called_functions(library,
                             break
                         else:
                             result['declarations'].add(name)
-                        # for lib in library._linking_libraries:
-                        #     for df in lib.get_defined_functions():
-                        #         if name == df.name:
-                        #             result['defined'].add(name)
-                        #             result['libraries'].add(lib)
-                        #             found = True
-                        #             q.append(name)
-                        #             break
-                        #     if found:
-                        #         break
-                        # if not found:
-                        #     result['declarations'].add(name)
                     else:
                         result['defined'].add(name)
                         q.append(name)

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -107,7 +107,6 @@ def get_called_functions(library,
                     if name.startswith('llvm.'):
                         result['intrinsics'].add(name)
                     elif f.is_declaration:
-                        found = False
                         if name in linked_functions:
                             lib = linked_functions.get(name)
                             result['defined'].add(name)

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -111,13 +111,11 @@ def get_called_functions(library,
                             lib = linked_functions.get(name)
                             result['defined'].add(name)
                             result['libraries'].add(lib)
-                            q.append(name)
                             break
                         else:
                             result['declarations'].add(name)
                     else:
                         result['defined'].add(name)
-                        q.append(name)
     return result
 
 

--- a/rbc/irtools.py
+++ b/rbc/irtools.py
@@ -55,7 +55,7 @@ def find_at_word(text: str) -> Optional[str]:
     return word[1:]
 
 
-def get_called_functions_bkp(library,
+def get_called_functions(library,
                          funcname: Optional[str] = None,
                          debug: bool = False) -> Dict[str, Set[str]]:
     result = defaultdict(set)
@@ -432,7 +432,7 @@ def compile_instance(func, sig,
         target.set_compile_target(None)
         raise
 
-    result = get_called_functions_bkp(cres.library, cres.fndesc.llvm_func_name, debug)
+    result = get_called_functions(cres.library, cres.fndesc.llvm_func_name, debug)
 
     for f in result['declarations']:
         if target.supports(f):
@@ -552,11 +552,11 @@ def compile_to_LLVM(functions_and_signatures,
         # Remove unused defined functions and declarations
         used_symbols = defaultdict(set)
         for fname in function_names:
-            symbols = get_called_functions_bkp(main_library, fname, debug)
+            symbols = get_called_functions(main_library, fname, debug)
             for k, v in symbols.items():
                 used_symbols[k].update(v)
 
-        all_symbols = get_called_functions_bkp(main_library, debug=debug)
+        all_symbols = get_called_functions(main_library, debug=debug)
 
         unused_symbols = defaultdict(set)
         for k, lst in all_symbols.items():

--- a/rbc/tests/heavydb/test_column_basic.py
+++ b/rbc/tests/heavydb/test_column_basic.py
@@ -473,10 +473,6 @@ def test_redefine(heavydb):
 def test_overload_nonuniform(heavydb, step):
     pytest.xfail('Test failing due to the introduction of default sizer. See PR 313')
 
-    # commented to avoid reseting existing tests
-    # heavydb.reset()
-    # heavydb.register()
-
     if step > 0:
         @heavydb('int32(Column<double>, RowMultiplier, OutputColumn<int64>)')  # noqa: E501, F811
         def overloaded_udtf(x, m, y):  # noqa: E501, F811


### PR DESCRIPTION
`get_called_functions` and `DTypeComparison.run_pass` where responsible for 80% of the compile-time in a single test:

Before:

<details>

```

  _     ._   __/__   _ _  _  _ _/_   Recorded: 00:46:45  Samples:  50578
 /_//_/// /_\ / //_// / //_'/ //     Duration: 54.667    CPU time: 55.333
/   _/                      v4.4.0

Program: pytest -rs -sv --tb=line -x rbc/tests/heavydb/test_nrt_string.py -k capitalize

54.165 pytest_pyfunc_call  _pytest/python.py:187
└─ 54.165 test_string_methods  rbc/tests/heavydb/test_nrt_string.py:164
   └─ 54.165 RemoteHeavyDB.sql_execute  rbc/heavydb/remoteheavydb.py:852
      └─ 53.804 RemoteHeavyDB.register  rbc/heavydb/remoteheavydb.py:1269
         └─ 53.799 RemoteHeavyDB._register  rbc/heavydb/remoteheavydb.py:1274
            └─ 53.122 compile_to_LLVM  rbc/irtools.py:418
               ├─ 32.919 get_called_functions  rbc/irtools.py:52
               │  └─ 32.795 get_called_functions  rbc/irtools.py:52
               │     ├─ 21.668 get_called_functions  rbc/irtools.py:52
               │     │  ├─ 10.613 get_called_functions  rbc/irtools.py:52
               │     │  │  ├─ 4.372 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
               │     │  │  │     [192 frames hidden]  numba, llvmlite, <built-in>
               │     │  │  ├─ 3.608 get_called_functions  rbc/irtools.py:52
               │     │  │  │  ├─ 1.370 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
               │     │  │  │  │     [167 frames hidden]  numba, llvmlite, <built-in>
               │     │  │  │  └─ 0.905 get_called_functions  rbc/irtools.py:52
               │     │  │  ├─ 0.838 ValueRef.opcode  llvmlite/binding/value.py:295
               │     │  │  │     [106 frames hidden]  llvmlite, numba, <built-in>, ctypes
               │     │  │  ├─ 0.680 ValueRef.name  llvmlite/binding/value.py:143
               │     │  │  │     [46 frames hidden]  llvmlite, numba, <built-in>
               │     │  │  └─ 0.601 _InstructionsIterator.__next__  llvmlite/binding/value.py:316
               │     │  │        [121 frames hidden]  llvmlite, numba, <built-in>
               │     │  ├─ 8.003 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
               │     │  │     [196 frames hidden]  numba, llvmlite, <built-in>
               │     │  ├─ 1.230 ValueRef.name  llvmlite/binding/value.py:143
               │     │  │     [46 frames hidden]  llvmlite, numba, <built-in>
               │     │  └─ 0.695 ValueRef.opcode  llvmlite/binding/value.py:295
               │     │        [106 frames hidden]  llvmlite, numba, <built-in>, ctypes
               │     ├─ 8.755 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
               │     │     [196 frames hidden]  numba, llvmlite, <built-in>
               │     └─ 1.277 ValueRef.name  llvmlite/binding/value.py:143
               │           [46 frames hidden]  llvmlite, numba, <built-in>
               ├─ 19.399 compile_instance  rbc/irtools.py:315
               │  ├─ 14.731 compile_extra  numba/core/compiler.py:690
               │  │     [5968 frames hidden]  numba, contextlib, llvmlite, <built-i...
               │  │        14.569 check  numba/core/compiler_machinery.py:272
               │  │        ├─ 11.387 DTypeComparison.run_pass  rbc/heavydb/pipeline.py:55
               │  │        │  └─ 11.387 PassManager.run  numba/core/compiler_machinery.py:342
               │  │        │        [31088 frames hidden]  numba, llvmlite, contextlib, abc, <bu...
               │  └─ 4.557 get_called_functions  rbc/irtools.py:52
               │     ├─ 2.726 get_called_functions  rbc/irtools.py:52
               │     │  └─ 2.218 get_called_functions  rbc/irtools.py:52
               │     │     └─ 1.239 get_called_functions  rbc/irtools.py:52
               │     └─ 1.471 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
               │           [177 frames hidden]  numba, llvmlite, <built-in>
               └─ 0.765 JITRemoteCodeLibrary._optimize_final_module  numba/core/codegen.py:667
                     [4 frames hidden]  numba, llvmlite
```

</details>


After:

<details>

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 00:44:48  Samples:  18110
 /_//_/// /_\ / //_// / //_'/ //     Duration: 21.513    CPU time: 22.342
/   _/                      v4.4.0

Program: pytest -rs -sv --tb=line -x rbc/tests/heavydb/test_nrt_string.py -k capitalize

21.005 pytest_pyfunc_call  _pytest/python.py:187
└─ 21.005 test_string_methods  rbc/tests/heavydb/test_nrt_string.py:164
   └─ 21.005 RemoteHeavyDB.sql_execute  rbc/heavydb/remoteheavydb.py:852
      ├─ 20.755 RemoteHeavyDB.register  rbc/heavydb/remoteheavydb.py:1269
      │  └─ 20.750 RemoteHeavyDB._register  rbc/heavydb/remoteheavydb.py:1274
      │     ├─ 20.123 compile_to_LLVM  rbc/irtools.py:424
      │     │  ├─ 16.543 compile_instance  rbc/irtools.py:320
      │     │  │  ├─ 14.593 compile_extra  numba/core/compiler.py:690
      │     │  │  │     [36678 frames hidden]  numba, contextlib, llvmlite, weakref,...
      │     │  │  └─ 1.844 get_called_functions  rbc/irtools.py:57
      │     │  │     ├─ 1.460 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
      │     │  │     │     [176 frames hidden]  numba, llvmlite, <built-in>
      │     │  │     └─ 0.220 ValueRef.name  llvmlite/binding/value.py:143
      │     │  │           [46 frames hidden]  llvmlite, numba, <built-in>
      │     │  ├─ 3.147 get_called_functions  rbc/irtools.py:57
      │     │  │  └─ 3.030 get_called_functions  rbc/irtools.py:57
      │     │  │     ├─ 2.236 JITRemoteCodeLibrary.get_defined_functions  numba/core/codegen.py:807
      │     │  │     │     [187 frames hidden]  numba, llvmlite, <built-in>
      │     │  │     └─ 0.377 ValueRef.name  llvmlite/binding/value.py:143
      │     │  │           [46 frames hidden]  llvmlite, numba, <built-in>
      │     │  └─ 0.392 JITRemoteCodeLibrary._optimize_final_module  numba/core/codegen.py:667
      │     │        [4 frames hidden]  numba, llvmlite
      │     ├─ 0.275 RemoteHeavyDB.thrift_call  rbc/heavydb/remoteheavydb.py:549
      │     │  └─ 0.275 Client.__call__  rbc/thrift/client.py:151
      │     │     └─ 0.274 TClient._req  thriftpy2/thrift.py:204
      │     │           [5 frames hidden]  thriftpy2, <built-in>
      │     └─ 0.271 RemoteHeavyDB.targets  rbc/remotejit.py:730
      │        └─ 0.271 RemoteHeavyDB.retrieve_targets  rbc/heavydb/remoteheavydb.py:1036
      └─ 0.249 RemoteHeavyDB.thrift_call  rbc/heavydb/remoteheavydb.py:549
         └─ 0.249 Client.__call__  rbc/thrift/client.py:151
            └─ 0.249 TClient._req  thriftpy2/thrift.py:204
                  [5 frames hidden]  thriftpy2, <built-in>
0.352 import_module  importlib/__init__.py:108
└─ 0.245 <module>  rbc/__init__.py:1
```

</details>