### PR TITLE
Update docs with tutorials and how-to sections

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -126,3 +126,14 @@ Array API
     stdlib.utility_functions
 
 
+Externals
+---------
+
+.. autosummary::
+    :toctree: generated/
+
+    externals.cmath
+    externals.libdevice
+    externals.macros
+    externals.heavydb
+    externals.stdio

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -126,14 +126,3 @@ Array API
     stdlib.utility_functions
 
 
-Externals
----------
-
-.. autosummary::
-    :toctree: generated/
-
-    externals.cmath
-    externals.libdevice
-    externals.macros
-    externals.heavydb
-    externals.stdio

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,3 +1,4 @@
+.. _API:
 .. currentmodule:: rbc
 
 =============

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,6 +53,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autosectionlabel',
     'numbadoc',
+    'myst_parser',
 ]
 
 # autosummary configuration

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,8 +53,11 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autosectionlabel',
     'numbadoc',
+    'sphinx_design',
     'myst_parser',
 ]
+
+myst_enable_extensions = ["colon_fence"]
 
 # autosummary configuration
 autosummary_generate = True

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -41,7 +41,7 @@ Then, to create an environment with a few of the most common dependencies:
 
 To activate the environment for the current shell session:
 
-.. code-block:: console
+.. code-block:: bash
 
     $ conda activate rbc
 
@@ -52,7 +52,7 @@ To activate the environment for the current shell session:
 Once the environment is activated, you have a dedicated Python with the
 required dependencies:
 
-.. code-block:: python
+.. code-block:: bash
 
     $ python
     >>> import llvmlite

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -34,6 +34,8 @@ howtos/array
 howtos/column
 howtos/text
 howtos/geo
+howtos/manager
+howtos/string_dict_proxy
 ```
 
 -----
@@ -46,5 +48,4 @@ caption: Advanced
 
 howtos/devices
 howtos/external_functions
-howtos/text
 ```

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -1,5 +1,5 @@
 
-## RBC how-tos
+# RBC how-tos
 
 These documents are intended as short recipes for common tasks using RBC. It is
 based on [NumPy how-tos](https://numpy.org/devdocs/user/howtos_index.html) and
@@ -11,11 +11,40 @@ property of the RBC project. For full content, check the tutorials page.
 ```{toctree}
 ---
 maxdepth: 1
+caption: Basics
 ---
 
 howtos/connect
-howtos/devices
-howtos/external_functions
+howtos/udf
+howtos/udtf
 howtos/raise_exception
 howtos/template
+```
+
+-----
+
+
+```{toctree}
+---
+maxdepth: 1
+caption: Datatypes
+---
+
+howtos/array
+howtos/column
+howtos/text
+howtos/geo
+```
+
+-----
+
+```{toctree}
+---
+maxdepth: 1
+caption: Advanced
+---
+
+howtos/devices
+howtos/external_functions
+howtos/text
 ```

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -1,0 +1,21 @@
+
+## RBC how-tos
+
+These documents are intended as short recipes for common tasks using RBC. It is
+based on [NumPy how-tos](https://numpy.org/devdocs/user/howtos_index.html) and
+[diataxis how to guide](https://diataxis.fr/how-to-guides/).
+
+How-tos are supposed to be short documents describing a specific feature or
+property of the RBC project. For full content, check the tutorials page.
+
+```{toctree}
+---
+maxdepth: 1
+---
+
+howtos/connect
+howtos/devices
+howtos/external_functions
+howtos/raise_exception
+howtos/template
+```

--- a/doc/howtos/array.md
+++ b/doc/howtos/array.md
@@ -1,0 +1,40 @@
+# Array type
+
+Arrays provide a convenient way to represent a sequence of values of the same
+type.
+
+### Building an array
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_array`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.array.new.begin
+:end-before: magictoken.udf.array.new.end
+:dedent: 4
+:linenos:
+```
+
+### Computing the length of an array
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_array`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.array.length.begin
+:end-before: magictoken.udf.array.length.end
+:dedent: 4
+:linenos:
+```
+
+### Using the [array_api](https://data-apis.org/array-api/2022.12/)
+
+RBC partially implements the array api standard. For a list of supported
+functions, check the [API](API) page.
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_array`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.array.array_api.begin
+:end-before: magictoken.udf.array.array_api.end
+:dedent: 4
+:linenos:
+```

--- a/doc/howtos/array.md
+++ b/doc/howtos/array.md
@@ -3,6 +3,8 @@
 Arrays provide a convenient way to represent a sequence of values of the same
 type.
 
+## Basics
+
 ### Building an array
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
@@ -14,6 +16,20 @@ type.
 :linenos:
 ```
 
+:::{dropdown} Example SQL Query
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geopoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.array.new.sql.begin
+:end-before: magictoken.udf.array.new.sql.end
+:dedent: 4
+:linenos:
+```
+
+:::
+
+
 ### Computing the length of an array
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
@@ -24,6 +40,19 @@ type.
 :dedent: 4
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geopoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.array.length.sql.begin
+:end-before: magictoken.udf.array.length.sql.end
+:dedent: 4
+:linenos:
+```
+
+:::
 
 ### Using the [array_api](https://data-apis.org/array-api/2022.12/)
 
@@ -38,3 +67,16 @@ functions, check the [API](API) page.
 :dedent: 4
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geopoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.array.array_api.sql.begin
+:end-before: magictoken.udf.array.array_api.sql.end
+:dedent: 4
+:linenos:
+```
+
+:::

--- a/doc/howtos/column.md
+++ b/doc/howtos/column.md
@@ -1,7 +1,7 @@
 # Column Type
 
-The Column type provide the structure and organization for storing and
-retrieving data within HeavyDB.
+The Column type provides the structure and organization for storing and
+retrieving columnar data within HeavyDB.
 
 ## Basic usage
 

--- a/doc/howtos/column.md
+++ b/doc/howtos/column.md
@@ -3,7 +3,7 @@
 The Column type provide the structure and organization for storing and
 retrieving data within HeavyDB.
 
-### Basic usage
+## Basic usage
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python
@@ -14,14 +14,15 @@ retrieving data within HeavyDB.
 :linenos:
 ```
 
-<details>
-<summary>Example SQL query</summary>
+:::{dropdown} Example SQL Query
 
-```sql
-SELECT * FROM TABLE(udtf_power(
-    cursor(SELECT * FROM TABLE(generate_series(1, 5)),
-    3
-));
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_column`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.column.basic.sql.begin
+:end-before: magictoken.udtf.column.basic.sql.end
+:dedent: 4
+:linenos:
 ```
 
-</details>
+:::

--- a/doc/howtos/column.md
+++ b/doc/howtos/column.md
@@ -1,0 +1,27 @@
+# Column Type
+
+The Column type provide the structure and organization for storing and
+retrieving data within HeavyDB.
+
+### Basic usage
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_column_power`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.column.basic.begin
+:end-before: magictoken.udtf.column.basic.end
+:dedent: 4
+:linenos:
+```
+
+<details>
+<summary>Example SQL query</summary>
+
+```sql
+SELECT * FROM TABLE(udtf_power(
+    cursor(SELECT * FROM TABLE(generate_series(1, 5)),
+    3
+));
+```
+
+</details>

--- a/doc/howtos/connect.md
+++ b/doc/howtos/connect.md
@@ -1,9 +1,12 @@
 
 (heavydb-connect)=
-## Connect to the HeavyDB server
+# Connect to the HeavyDB server
 
-```python
-from rbc.heavydb import RemoteHeavyDB
-heavydb = RemoteHeavyDB(user='admin', password='HyperInteractive',
-                        host='127.0.0.1', port=6274)
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_connect`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.connect.begin
+:end-before: magictoken.connect.end
+:dedent: 4
+:linenos:
 ```

--- a/doc/howtos/connect.md
+++ b/doc/howtos/connect.md
@@ -1,0 +1,9 @@
+
+(heavydb-connect)=
+## Connect to the HeavyDB server
+
+```python
+from rbc.heavydb import RemoteHeavyDB
+heavydb = RemoteHeavyDB(user='admin', password='HyperInteractive',
+                        host='127.0.0.1', port=6274)
+```

--- a/doc/howtos/devices.md
+++ b/doc/howtos/devices.md
@@ -13,3 +13,14 @@ Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
 ```
 
 By default, both devices are used if available. Otherwise, only the CPU is used.
+
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_devices`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.devices.sql.begin
+:end-before: magictoken.devices.sql.end
+:dedent: 4
+:linenos:
+```
+:::

--- a/doc/howtos/devices.md
+++ b/doc/howtos/devices.md
@@ -1,12 +1,15 @@
 
-## Stricting a function to run in a specific device (CPU/GPU)
+# Stricting a function to run in a specific device (CPU/GPU)
 
 Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
 
-```python
-@heavydb('int32(int32, int32)', devices=['CPU', 'GPU'])
-def add(a, b):
-    return a + b
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_devices`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.devices.begin
+:end-before: magictoken.devices.end
+:dedent: 4
+:linenos:
 ```
 
 By default, both devices are used if available. Otherwise, only the CPU is used.

--- a/doc/howtos/devices.md
+++ b/doc/howtos/devices.md
@@ -1,5 +1,4 @@
-
-# Stricting a function to run in a specific device (CPU/GPU)
+# Restricting a function to run only in a specific device (CPU/GPU)
 
 Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
 

--- a/doc/howtos/devices.md
+++ b/doc/howtos/devices.md
@@ -1,0 +1,12 @@
+
+## Stricting a function to run in a specific device (CPU/GPU)
+
+Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
+
+```python
+@heavydb('int32(int32, int32)', devices=['CPU', 'GPU'])
+def add(a, b):
+    return a + b
+```
+
+By default, both devices are used if available. Otherwise, only the CPU is used.

--- a/doc/howtos/external_functions.md
+++ b/doc/howtos/external_functions.md
@@ -1,33 +1,30 @@
 
-## Defining and using external functions
+# Defining and using external functions
+
+## cmath `abs`
 
 The `external` keyword provide a way of calling C functions defined in other
 libraries within python code.
 
-```python
-from rbc.external import external
-cmath_abs = external('int64 abs(int64)')
-
-@heavydb('int64(int64)')
-def apply_abs(x):
-    return cmath_abs(x)
-
-heavydb.sql_execute('SELECT apply_abs(-3);')
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_external_functions`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.external_functions.abs.begin
+:end-before: magictoken.external_functions.abs.end
+:dedent: 4
+:linenos:
 ```
 
 RBC already exposes a small set of C functions from the C stdlib. Check the API
 reference page for more details.
 
-### Using `printf`
+## Using `printf`
 
-```python
-from rbc.externals.stdio import printf
-
-@heavydb('int64(int64)')
-def power_2(x):
-    # This message will show in the heavydb logs
-    printf("input number: %d\n", x)
-    return x * x
-
-heavydb.sql_execute('SELECT power_2(3);')
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_external_functions`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.external_functions.printf.begin
+:end-before: magictoken.external_functions.printf.end
+:dedent: 4
+:linenos:
 ```

--- a/doc/howtos/external_functions.md
+++ b/doc/howtos/external_functions.md
@@ -1,0 +1,33 @@
+
+## Defining and using external functions
+
+The `external` keyword provide a way of calling C functions defined in other
+libraries within python code.
+
+```python
+from rbc.external import external
+cmath_abs = external('int64 abs(int64)')
+
+@heavydb('int64(int64)')
+def apply_abs(x):
+    return cmath_abs(x)
+
+heavydb.sql_execute('SELECT apply_abs(-3);')
+```
+
+RBC already exposes a small set of C functions from the C stdlib. Check the API
+reference page for more details.
+
+### Using `printf`
+
+```python
+from rbc.externals.stdio import printf
+
+@heavydb('int64(int64)')
+def power_2(x):
+    # This message will show in the heavydb logs
+    printf("input number: %d\n", x)
+    return x * x
+
+heavydb.sql_execute('SELECT power_2(3);')
+```

--- a/doc/howtos/external_functions.md
+++ b/doc/howtos/external_functions.md
@@ -15,6 +15,17 @@ libraries within python code.
 :linenos:
 ```
 
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_external_functions`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.external_functions.abs.sql.begin
+:end-before: magictoken.external_functions.abs.sql.end
+:dedent: 4
+:linenos:
+```
+:::
+
 RBC already exposes a small set of C functions from the C stdlib. Check the API
 reference page for more details.
 
@@ -28,3 +39,14 @@ reference page for more details.
 :dedent: 4
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_external_functions`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.external_functions.printf.sql.begin
+:end-before: magictoken.external_functions.printf.sql.end
+:dedent: 4
+:linenos:
+```
+:::

--- a/doc/howtos/external_functions.md
+++ b/doc/howtos/external_functions.md
@@ -3,8 +3,8 @@
 
 ## cmath `abs`
 
-The `external` keyword provide a way of calling C functions defined in other
-libraries within python code.
+The `external` keyword provides a way of calling C functions defined in other
+libraries within Python code.
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python

--- a/doc/howtos/geo.md
+++ b/doc/howtos/geo.md
@@ -1,7 +1,7 @@
 # Geometry Types
 
-HeavyDB offers an expanded range of geometry types, encompassing `(Multi)Point`,
-`(Multi)LineString`, and `(Multi)Polygon`.
+HeavyDB offers an extensive range of geometry types, encompassing
+`(Multi)Point`, `(Multi)LineString`, and `(Multi)Polygon`.
 
 ## Basics
 
@@ -33,7 +33,7 @@ HeavyDB offers an expanded range of geometry types, encompassing `(Multi)Point`,
 ### `GeoMultiPoint`
 
 `MultiPoint` works a bit different than `Point`. They are created by calling
-`.from_coords` method.
+the `.from_coords` method.
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python

--- a/doc/howtos/geo.md
+++ b/doc/howtos/geo.md
@@ -16,8 +16,7 @@ HeavyDB offers an expanded range of geometry types, encompassing `(Multi)Point`,
 :linenos:
 ```
 
-<details>
-<summary>Example SQL query</summary>
+:::{dropdown} Example SQL Query
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python
@@ -28,4 +27,32 @@ HeavyDB offers an expanded range of geometry types, encompassing `(Multi)Point`,
 :linenos:
 ```
 
-</details>
+:::
+
+
+### `GeoMultiPoint`
+
+`MultiPoint` works a bit different than `Point`. They are created by calling
+`.from_coords` method.
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geomultipoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.mp.basic.begin
+:end-before: magictoken.udtf.mp.basic.end
+:dedent: 4
+:linenos:
+```
+
+:::{dropdown} Example SQL Query
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geopoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.mp.basic.sql.begin
+:end-before: magictoken.udtf.mp.basic.sql.end
+:dedent: 4
+:linenos:
+```
+
+:::

--- a/doc/howtos/geo.md
+++ b/doc/howtos/geo.md
@@ -1,0 +1,31 @@
+# Geometry Types
+
+HeavyDB offers an expanded range of geometry types, encompassing `(Multi)Point`,
+`(Multi)LineString`, and `(Multi)Polygon`.
+
+## Basics
+
+### `GeoPoint`
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geopoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.geopoint.basic.begin
+:end-before: magictoken.udtf.geopoint.basic.end
+:dedent: 4
+:linenos:
+```
+
+<details>
+<summary>Example SQL query</summary>
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_geopoint`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.geopoint.basic.sql.begin
+:end-before: magictoken.udtf.geopoint.basic.sql.end
+:dedent: 4
+:linenos:
+```
+
+</details>

--- a/doc/howtos/manager.md
+++ b/doc/howtos/manager.md
@@ -1,0 +1,48 @@
+# Table/Row Function Manager
+
+The function manager in HeavyDB provides a convenient mechanism of handling the
+state of user-defined functions. It can perform various tasks such as
+allocating memory for output buffers, retrieve dictionary encoded strings in
+the [dictionary proxy](string-dict-proxy), and raise exceptions.
+
+## Table Function Manager
+
+### Basic usage
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_mgr`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.mgr.basic.begin
+:end-before: magictoken.udtf.mgr.basic.end
+:dedent: 4
+:linenos:
+```
+
+### Retrieving the dictionary string proxy
+
+When the Column has type `TextEncodingDict`, users can access the dictionary
+string proxy by calling the `string_dict_proxy` attribute:
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udtf_string_proxy`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.proxy.begin
+:end-before: magictoken.udtf.proxy.end
+:dedent: 4
+:linenos:
+```
+
+For additional information and references, please refer to the [API](API) page
+and the dedicated [how-to](string-dict-proxy) page on the string dictionary
+proxy in HeavyDB.
+
+## Row Function Manager
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_mgr`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.mgr.basic.begin
+:end-before: magictoken.udf.mgr.basic.end
+:dedent: 8
+:linenos:
+```

--- a/doc/howtos/manager.md
+++ b/doc/howtos/manager.md
@@ -1,8 +1,8 @@
 # Table/Row Function Manager
 
-The function manager in HeavyDB provides a convenient mechanism of handling the
-state of user-defined functions. It can perform various tasks such as
-allocating memory for output buffers, retrieve dictionary encoded strings in
+The function managers in HeavyDB provide a convenient mechanism of handling the
+state of user-defined functions. They can perform various tasks such as
+allocate memory for output buffers, retrieve dictionary encoded strings in
 the [dictionary proxy](string-dict-proxy), and raise exceptions.
 
 ## Table Function Manager

--- a/doc/howtos/manager.md
+++ b/doc/howtos/manager.md
@@ -11,12 +11,23 @@ the [dictionary proxy](string-dict-proxy), and raise exceptions.
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python
-:caption: from ``test_mgr`` of ``rbc/tests/heavydb/test_howtos.py``
+:caption: from ``test_tablefunctionmanager`` of ``rbc/tests/heavydb/test_howtos.py``
 :start-after: magictoken.udtf.mgr.basic.begin
 :end-before: magictoken.udtf.mgr.basic.end
 :dedent: 4
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_tablefunctionmanager`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.mgr.basic.sql.begin
+:end-before: magictoken.udtf.mgr.basic.sql.end
+:dedent: 4
+:linenos:
+```
+:::
 
 ### Retrieving the dictionary string proxy
 
@@ -40,9 +51,20 @@ proxy in HeavyDB.
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python
-:caption: from ``test_mgr`` of ``rbc/tests/heavydb/test_howtos.py``
+:caption: from ``test_rowfunctionmanager`` of ``rbc/tests/heavydb/test_howtos.py``
 :start-after: magictoken.udf.mgr.basic.begin
 :end-before: magictoken.udf.mgr.basic.end
 :dedent: 8
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_rowfunctionmanager`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.mgr.basic.sql.begin
+:end-before: magictoken.udf.mgr.basic.sql.end
+:dedent: 8
+:linenos:
+```
+:::

--- a/doc/howtos/raise_exception.md
+++ b/doc/howtos/raise_exception.md
@@ -1,0 +1,27 @@
+
+## Raising exceptions
+
+Exceptions in HeavyDB are quite different from the ones used in Python. In RBC
+code, you signal to the database an exception happened by calling a specific
+method (`error_message`) in the runner manager.
+
+### In a UDTF
+
+```python
+@heavydb('int32(TableFunctionManager, Column<int>, OutputColumn<int>)')
+def udtf_copy(mgr, inp, out):
+    size = len(inp)
+    if size > 5:
+        # error message must be known at compile-time
+        return mgr.error_message('Can only copy up to 5 rows')
+
+    mgr.set_output_row_size(size)
+    for i in range(size):
+        out[i] = inp[i]
+    return size
+```
+
+### In a UDF:
+
+It is currently not possible to raise an exception in a UDF. The server must
+implement support for it first before RBC can support it.

--- a/doc/howtos/raise_exception.md
+++ b/doc/howtos/raise_exception.md
@@ -5,6 +5,11 @@ Exceptions in HeavyDB are quite different from the ones used in Python. In RBC
 code, you signal to the database an exception happened by calling a specific
 method (`error_message`) in the runner manager.
 
+## In a UDF:
+
+It is currently not possible to raise an exception in a UDF. The server must
+implement support for it first before RBC can support it.
+
 ## In a UDTF
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
@@ -16,7 +21,13 @@ method (`error_message`) in the runner manager.
 :linenos:
 ```
 
-## In a UDF:
-
-It is currently not possible to raise an exception in a UDF. The server must
-implement support for it first before RBC can support it.
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_raise_exception`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.raise_exception.sql.begin
+:end-before: magictoken.raise_exception.sql.end
+:dedent: 4
+:linenos:
+```
+:::

--- a/doc/howtos/raise_exception.md
+++ b/doc/howtos/raise_exception.md
@@ -1,27 +1,22 @@
 
-## Raising exceptions
+# Raising exceptions
 
 Exceptions in HeavyDB are quite different from the ones used in Python. In RBC
 code, you signal to the database an exception happened by calling a specific
 method (`error_message`) in the runner manager.
 
-### In a UDTF
+## In a UDTF
 
-```python
-@heavydb('int32(TableFunctionManager, Column<int>, OutputColumn<int>)')
-def udtf_copy(mgr, inp, out):
-    size = len(inp)
-    if size > 5:
-        # error message must be known at compile-time
-        return mgr.error_message('Can only copy up to 5 rows')
-
-    mgr.set_output_row_size(size)
-    for i in range(size):
-        out[i] = inp[i]
-    return size
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_raise_exception`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.raise_exception.begin
+:end-before: magictoken.raise_exception.end
+:dedent: 4
+:linenos:
 ```
 
-### In a UDF:
+## In a UDF:
 
 It is currently not possible to raise an exception in a UDF. The server must
 implement support for it first before RBC can support it.

--- a/doc/howtos/string_dict_proxy.md
+++ b/doc/howtos/string_dict_proxy.md
@@ -1,0 +1,32 @@
+(string-dict-proxy)=
+# String Dictionary Proxy
+
+The string dictionary proxy provides a convenient way for retrieving encoded
+strings within the database. It works by maintaining a lookup table that maps
+string values to unique integer identifiers.
+
+## Retrieving the dictionary proxy
+
+### From `RowFunctionManager`
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_text`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.proxy.begin
+:end-before: magictoken.udf.proxy.end
+:dedent: 8
+:linenos:
+```
+
+### From `TableFunctionManager`
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_text`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.proxy.begin
+:end-before: magictoken.udtf.proxy.end
+:dedent: 4
+:linenos:
+```
+
+Check the [API reference page](API) for a full list of table methods

--- a/doc/howtos/template.md
+++ b/doc/howtos/template.md
@@ -1,15 +1,18 @@
 
-## Using templates
+# Using templates
 
 Templates are generic types used in the decorator `@heavydb`. Templating allows
 the target function to accept different data types for its arguments.
 
 Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
 
-```python
-@heavydb('Z(T, Z)', T=['int32', 'float'], Z=['int64', 'double'])
-def add(a, b):
-    return a + b
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_templates`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.templates.begin
+:end-before: magictoken.templates.end
+:dedent: 4
+:linenos:
 ```
 
 In the case above, the template arguments `T` and `Z`, are specified within the

--- a/doc/howtos/template.md
+++ b/doc/howtos/template.md
@@ -18,3 +18,15 @@ Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
 In the case above, the template arguments `T` and `Z`, are specified within the
 decorator, indicating the valid data types that can be used for the `add`
 function.
+
+
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_templates`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.templates.sql.begin
+:end-before: magictoken.templates.sql.end
+:dedent: 4
+:linenos:
+```
+:::

--- a/doc/howtos/template.md
+++ b/doc/howtos/template.md
@@ -1,0 +1,17 @@
+
+## Using templates
+
+Templates are generic types used in the decorator `@heavydb`. Templating allows
+the target function to accept different data types for its arguments.
+
+Assuming you already have a [connection](heavydb-connect) to the HeavyDB server:
+
+```python
+@heavydb('Z(T, Z)', T=['int32', 'float'], Z=['int64', 'double'])
+def add(a, b):
+    return a + b
+```
+
+In the case above, the template arguments `T` and `Z`, are specified within the
+decorator, indicating the valid data types that can be used for the `add`
+function.

--- a/doc/howtos/text.md
+++ b/doc/howtos/text.md
@@ -11,6 +11,7 @@ space and encoding/decoding overhead.
 
 ## Defining an UDF with Text types:
 
+(example-1)=
 ### Encoding dict
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python
@@ -21,13 +22,33 @@ space and encoding/decoding overhead.
 :linenos:
 ```
 
-
 ### Encoding none
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
 :language: python
 :caption: from ``test_udf_text`` of ``rbc/tests/heavydb/test_howtos.py``
 :start-after: magictoken.udf.text.none.begin
 :end-before: magictoken.udf.text.none.end
-:dedent: 8
+:dedent: 4
 :linenos:
 ```
+
+### Converting a Text Encoding None to a string
+
+Text encoding none objects feature a handy `to_string()` method for converting
+the object into a *Python Unicode* type.
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_text`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.text.capitalize.begin
+:end-before: magictoken.udf.text.capitalize.end
+:dedent: 4
+:linenos:
+```
+
+Check the Numba [readthedocs page](https://numba.readthedocs.io/en/stable/reference/pysupported.html#str)
+for a list of supported string methods.
+
+### Converting a Text Encoding Dict to a string
+
+See the [first example](example-1) in this page.

--- a/doc/howtos/text.md
+++ b/doc/howtos/text.md
@@ -1,0 +1,33 @@
+# Text types
+
+HeavyDB supports two text encoding options: `TEXT ENCODING NONE` and
+`TEXT ENCODING DICT`.
+
+`TEXT ENCODING NONE` stores textual data without compression, while
+`TEXT ENCODING DICT` uses dictionary-based encoding to reduce storage
+requirements by replacing common words or phrases with shorter codes.
+The choice depends on data characteristics and the trade-off between storage
+space and encoding/decoding overhead.
+
+## Defining an UDF with Text types:
+
+### Encoding dict
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_text`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.text.dict.begin
+:end-before: magictoken.udf.text.dict.end
+:dedent: 8
+:linenos:
+```
+
+
+### Encoding none
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf_text`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.text.none.begin
+:end-before: magictoken.udf.text.none.end
+:dedent: 8
+:linenos:
+```

--- a/doc/howtos/udf.md
+++ b/doc/howtos/udf.md
@@ -2,7 +2,7 @@
 
 ## Basics
 
-UDFs are function that operate at row-level. That is, they receive as input a
+UDFs are functions that operate at row-level. That is, they receive as input a
 single row at a time.
 
 ```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py

--- a/doc/howtos/udf.md
+++ b/doc/howtos/udf.md
@@ -1,0 +1,26 @@
+# User Defined Functions (UDFs)
+
+UDFs are function that operate at row-level. That is, they receive as input a
+single row at a time.
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.begin
+:end-before: magictoken.udf.end
+:dedent: 4
+:linenos:
+```
+
+## Multiple signatures
+
+Defining UDFs with multiple signatures
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udf`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.multiple_signatures.begin
+:end-before: magictoken.udf.multiple_signatures.end
+:dedent: 4
+:linenos:
+```

--- a/doc/howtos/udf.md
+++ b/doc/howtos/udf.md
@@ -1,5 +1,7 @@
 # User Defined Functions (UDFs)
 
+## Basics
+
 UDFs are function that operate at row-level. That is, they receive as input a
 single row at a time.
 
@@ -11,6 +13,20 @@ single row at a time.
 :dedent: 4
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_column`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.sql.begin
+:end-before: magictoken.udf.sql.end
+:dedent: 4
+:linenos:
+```
+
+:::
+
 
 ## Multiple signatures
 
@@ -24,3 +40,16 @@ Defining UDFs with multiple signatures
 :dedent: 4
 :linenos:
 ```
+
+:::{dropdown} Example SQL Query
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_column`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udf.multiple_signatures.sql.begin
+:end-before: magictoken.udf.multiple_signatures.sql.end
+:dedent: 4
+:linenos:
+```
+
+:::

--- a/doc/howtos/udtf.md
+++ b/doc/howtos/udtf.md
@@ -1,0 +1,13 @@
+# User Defined Table Functions (UDTFs)
+
+UDTFs are functions that operate on a column-level basis. In simpler terms,
+UDTFs take a set of columns as input and return a set of columns as output.
+
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udtf`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.begin
+:end-before: magictoken.udtf.end
+:dedent: 4
+:linenos:
+```

--- a/doc/howtos/udtf.md
+++ b/doc/howtos/udtf.md
@@ -11,3 +11,15 @@ UDTFs take a set of columns as input and return a set of columns as output.
 :dedent: 4
 :linenos:
 ```
+
+
+:::{dropdown} Example SQL Query
+```{literalinclude} ../../rbc/tests/heavydb/test_howtos.py
+:language: python
+:caption: from ``test_udtf`` of ``rbc/tests/heavydb/test_howtos.py``
+:start-after: magictoken.udtf.sql.begin
+:end-before: magictoken.udtf.sql.end
+:dedent: 4
+:linenos:
+```
+:::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,12 +15,25 @@ A Python package implementing a remote backend compiler using numba
 and llvmlite tools.
 
 .. toctree::
+   :caption: Getting started
    :maxdepth: 1
-   :caption: Contents:
 
    design
+   installation
+
+.. toctree::
+   :caption: Fundamentals and usage
+   :maxdepth: 1
+
+   howto
+   tutorials
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference Manual:
+
    api
-   releases
+   envvars
    developer
    nrt
-   envvars
+   releases

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,5 +1,5 @@
 
-## Installation
+# Installation
 
 RBC is available on both conda-forge and PyPI.
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,0 +1,24 @@
+
+## Installation
+
+RBC is available on both conda-forge and PyPI.
+
+### conda/mamba
+
+You can use either [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
+or [mamba](https://github.com/mamba-org/mamba) to install RBC. We suggest using
+mamba as it uses a faster solver.
+
+```bash
+conda create --name rbc_env
+conda activate rbc_env
+conda install -c conda-forge rbc
+```
+
+### Pip
+
+On PyPI, the RBC library is called `rbc-project`.
+
+```bash
+pip install rbc-project
+```

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -1,7 +1,7 @@
 
 # RBC tutorials
 
-Different from how to guides, tutorials are longer and cover a broader set of
+Unlike how-to guides, tutorials are longer and cover a broader set of
 features available in the RBC project. These tutorials are usually jupyter
 notebooks available in the `notebooks` repo and rendered here.
 

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -1,5 +1,5 @@
 
-## RBC tutorials
+# RBC tutorials
 
 Different from how to guides, tutorials are longer and cover a broader set of
 features available in the RBC project. These tutorials are usually jupyter

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -1,0 +1,11 @@
+
+## RBC tutorials
+
+Different from how to guides, tutorials are longer and cover a broader set of
+features available in the RBC project. These tutorials are usually jupyter
+notebooks available in the `notebooks` repo and rendered here.
+
+* [RBC intro](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-intro.ipynb)
+* [Using RBC with Ibis](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-ibis.ipynb)
+* [Defining and using external functions](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-external-fns.ipynb)
+* [Case study - Black Scholes model](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-black-scholes.ipynb)

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -5,7 +5,35 @@ Different from how to guides, tutorials are longer and cover a broader set of
 features available in the RBC project. These tutorials are usually jupyter
 notebooks available in the `notebooks` repo and rendered here.
 
-* [RBC intro](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-intro.ipynb)
-* [Using RBC with Ibis](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-ibis.ipynb)
-* [Defining and using external functions](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-external-fns.ipynb)
-* [Case study - Black Scholes model](https://github.com/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-black-scholes.ipynb)
+
+```{toctree}
+---
+maxdepth: 1
+caption: Basics
+---
+
+tutorials/intro
+```
+
+------------
+
+```{toctree}
+---
+maxdepth: 1
+caption: Advanced
+---
+
+tutorials/ibis
+tutorials/external_fns
+```
+
+------------
+
+```{toctree}
+---
+maxdepth: 1
+caption: Case Study
+---
+
+tutorials/black_scholes
+```

--- a/doc/tutorials/black_scholes.md
+++ b/doc/tutorials/black_scholes.md
@@ -1,0 +1,11 @@
+
+# Case Study - Black Scholes model
+
+<div class="container" style="">
+    <div style="position:relative">
+        <iframe style="border: 0px" height="3500em" scrolling="no" width="100%"
+                src="https://nbviewer.org/github/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-black-scholes.ipynb"></iframe>
+        <a style="position:absolute; top:0; left:0; height:100%; width: 100%; z-index:5;" href="">
+        </a>
+    </div>
+</div>

--- a/doc/tutorials/external_fns.md
+++ b/doc/tutorials/external_fns.md
@@ -4,7 +4,7 @@
 <div class="container" style="">
     <div style="position:relative">
         <iframe style="border: 0px" height="3500em" scrolling="no" width="100%"
-                src="https://nbviewer.org/github/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-external_fns.ipynb"></iframe>
+                src="https://nbviewer.org/github/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-external-fns.ipynb"></iframe>
         <a style="position:absolute; top:0; left:0; height:100%; width: 100%; z-index:5;" href="">
         </a>
     </div>

--- a/doc/tutorials/external_fns.md
+++ b/doc/tutorials/external_fns.md
@@ -1,5 +1,5 @@
 
-# Using RBC with Ibis framework
+# Defining and calling external functions
 
 <div class="container" style="">
     <div style="position:relative">

--- a/doc/tutorials/external_fns.md
+++ b/doc/tutorials/external_fns.md
@@ -1,0 +1,11 @@
+
+# Using RBC with Ibis framework
+
+<div class="container" style="">
+    <div style="position:relative">
+        <iframe style="border: 0px" height="3500em" scrolling="no" width="100%"
+                src="https://nbviewer.org/github/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-external_fns.ipynb"></iframe>
+        <a style="position:absolute; top:0; left:0; height:100%; width: 100%; z-index:5;" href="">
+        </a>
+    </div>
+</div>

--- a/doc/tutorials/ibis.md
+++ b/doc/tutorials/ibis.md
@@ -1,0 +1,11 @@
+
+# Using RBC with Ibis framework
+
+<div class="container" style="">
+    <div style="position:relative">
+        <iframe style="border: 0px" height="3500em" scrolling="no" width="100%"
+                src="https://nbviewer.org/github/xnd-project/rbc/blob/main/notebooks/rbc-heavydb-ibis.ipynb"></iframe>
+        <a style="position:absolute; top:0; left:0; height:100%; width: 100%; z-index:5;" href="">
+        </a>
+    </div>
+</div>

--- a/doc/tutorials/intro.md
+++ b/doc/tutorials/intro.md
@@ -1,0 +1,11 @@
+
+# RBC Basics
+
+<div class="container" style="">
+    <div style="position:relative">
+        <iframe style="border: 0px" height="3500em" scrolling="no" width="100%"
+                src="https://nbviewer.org/github/xnd-project/rbc/blob/main/notebooks/rbc-intro.ipynb"></iframe>
+        <a style="position:absolute; top:0; left:0; height:100%; width: 100%; z-index:5;" href="">
+        </a>
+    </div>
+</div>

--- a/rbc/heavydb/geomultipoint.py
+++ b/rbc/heavydb/geomultipoint.py
@@ -16,12 +16,16 @@ from .geo_nested_array import (GeoNestedArray, GeoNestedArrayNumbaType,
 
 
 class GeoMultiPointNumbaType(GeoNestedArrayNumbaType):
-    def __init__(self):
-        super().__init__(name="GeoMultiPointNumbaType")
+    def __init__(self, name):
+        super().__init__(name)
 
 
 class HeavyDBGeoMultiPointType(HeavyDBGeoNestedArray):
     """Typesystem type class for HeavyDB buffer structures."""
+
+    @property
+    def numba_type(self):
+        return GeoMultiPointNumbaType
 
     @property
     def type_name(self):

--- a/rbc/heavydb/point2d.py
+++ b/rbc/heavydb/point2d.py
@@ -64,18 +64,18 @@ class HeavyDBPoint2D(typesystem.Type):
 @extending.type_callable(Point2D)
 def type_heavydb_point2d(context):
     def typer(x, y):
-        if isinstance(x, nb_types.Float) and isinstance(y, nb_types.Float):
+        if isinstance(x, nb_types.Number) and isinstance(y, nb_types.Number):
             return typesystem.Type.fromobject('Point2D').tonumba()
     return typer
 
 
-@extending.lower_builtin(Point2D, nb_types.Float, nb_types.Float)
+@extending.lower_builtin(Point2D, nb_types.Number, nb_types.Number)
 def heavydb_point2d_ctor(context, builder, sig, args):
     [x, y] = args
     typ = sig.return_type
     point = cgutils.create_struct_proxy(typ)(context, builder)
-    point.x = x
-    point.y = y
+    point.x = context.cast(builder, x, sig.args[0], nb_types.double)
+    point.y = context.cast(builder, y, sig.args[1], nb_types.double)
     return point._getvalue()
 
 

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -1,7 +1,7 @@
 __all__ = ['HeavyDBTableFunctionManagerType', 'TableFunctionManager']
 
 
-from numba.core import extending, typing
+from numba.core import extending
 from numba.core import types as nb_types
 
 from rbc.errors import RequireLiteralValue, UnsupportedError
@@ -11,7 +11,6 @@ from rbc.targetinfo import TargetInfo
 from .metatype import HeavyDBMetaType
 from .opaque_pointer import HeavyDBOpaquePtr, OpaquePtrNumbaType
 from .utils import as_voidptr, global_str_constant
-from .string_dict_proxy import StringDictionaryProxyNumbaType
 
 
 class HeavyDBTableFunctionManagerType(HeavyDBOpaquePtr):

--- a/rbc/heavydb/table_function_manager.py
+++ b/rbc/heavydb/table_function_manager.py
@@ -1,7 +1,7 @@
 __all__ = ['HeavyDBTableFunctionManagerType', 'TableFunctionManager']
 
 
-from numba.core import extending
+from numba.core import extending, typing
 from numba.core import types as nb_types
 
 from rbc.errors import RequireLiteralValue, UnsupportedError
@@ -11,6 +11,7 @@ from rbc.targetinfo import TargetInfo
 from .metatype import HeavyDBMetaType
 from .opaque_pointer import HeavyDBOpaquePtr, OpaquePtrNumbaType
 from .utils import as_voidptr, global_str_constant
+from .string_dict_proxy import StringDictionaryProxyNumbaType
 
 
 class HeavyDBTableFunctionManagerType(HeavyDBOpaquePtr):

--- a/rbc/tests/heavydb/test_howtos.py
+++ b/rbc/tests/heavydb/test_howtos.py
@@ -117,8 +117,10 @@ def test_udf(heavydb):
         return a + 1
     # magictoken.udf.end
 
+    # magictoken.udf.sql.begin
     _, result = heavydb.sql_execute('SELECT incr(3)')
     assert list(result) == [(4,)]
+    # magictoken.udf.sql.end
 
     heavydb.unregister()
 
@@ -127,8 +129,11 @@ def test_udf(heavydb):
     def multiply(a, b):
         return a * b
     # magictoken.udf.multiple_signatures.end
+
+    # magictoken.udf.multiple_signatures.sql.begin
     _, result = heavydb.sql_execute('SELECT multiply(3.0, 2.0)')
     assert list(result) == [(6.0,)]
+    # magictoken.udf.multiple_signatures.sql.end
 
 
 def test_udtf(heavydb):
@@ -284,8 +289,10 @@ def test_array(heavydb):
         return arr
     # magictoken.udf.array.new.end
 
+    # magictoken.udf.array.new.sql.begin
     _, r = heavydb.sql_execute('SELECT arr_new(5);')
     assert list(r) == [([1, 1, 1, 1, 1],)]
+    # magictoken.udf.array.new.sql.end
 
     # magictoken.udf.array.length.begin
     @heavydb('int64(Array<int32>)')
@@ -293,8 +300,10 @@ def test_array(heavydb):
         return len(arr)
     # magictoken.udf.array.length.end
 
+    # magictoken.udf.array.length.sql.begin
     _, r = heavydb.sql_execute(f'SELECT my_length(i4) from {table_name}')
     assert list(r) == [(0,), (1,), (2,), (3,), (4,)]
+    # magictoken.udf.array.length.sql.end
 
     # magictoken.udf.array.array_api.begin
     from rbc.stdlib import array_api
@@ -304,9 +313,10 @@ def test_array(heavydb):
         return array_api.ones(sz, dtype='int64')
     # magictoken.udf.array.array_api.end
 
+    # magictoken.udf.array.array_api.sql.begin
     _, r = heavydb.sql_execute('SELECT arr_new_ones(5);')
     assert list(r) == [([1, 1, 1, 1, 1],)]
-
+    # magictoken.udf.array.array_api.sql.end
 
 def test_tablefunctionmanager(heavydb):
     heavydb.unregister()

--- a/rbc/tests/heavydb/test_howtos.py
+++ b/rbc/tests/heavydb/test_howtos.py
@@ -355,8 +355,6 @@ def test_rowfunctionmanager(heavydb):
 
     if heavydb.version[:2] >= (6, 4):
         # magictoken.udf.mgr.basic.begin
-        from rbc.heavydb import TextEncodingNone
-
         @heavydb('TextEncodingDict(RowFunctionManager, TextEncodingDict)')
         def concat(mgr, text):
             db_id: int = mgr.get_dict_db_id('concat', 0)

--- a/rbc/tests/heavydb/test_howtos.py
+++ b/rbc/tests/heavydb/test_howtos.py
@@ -1,0 +1,105 @@
+# tests for how-tos page
+# ensure that examples in the docs page are correct
+import pytest
+from rbc.errors import HeavyDBServerError
+from rbc.tests import heavydb_fixture
+
+
+@pytest.fixture(scope='module')
+def heavydb():
+    for o in heavydb_fixture(globals()):
+        yield o
+
+
+def test_connect(heavydb):
+    # magictoken.connect.begin
+    from rbc.heavydb import RemoteHeavyDB
+    heavy = RemoteHeavyDB(user='admin', password='HyperInteractive',
+                          host='127.0.0.1', port=6274)
+    # magictoken.connect.end
+    assert heavy.version is not None
+
+
+def test_external_functions(heavydb):
+    # magictoken.external_functions.abs.begin
+    from rbc.external import external
+    cmath_abs = external('int64 abs(int64)')
+
+    @heavydb('int64(int64)')
+    def apply_abs(x):
+        return cmath_abs(x)
+
+    _, result = heavydb.sql_execute('SELECT apply_abs(-3);')
+    # magictoken.external_functions.abs.end
+    assert list(result) == [(3,)]
+
+    # magictoken.external_functions.printf.begin
+    from rbc.externals.stdio import printf
+
+    @heavydb('int64(int64)')
+    def power_2(x):
+        # This message will show in the heavydb logs
+        printf("input number: %d\n", x)
+        return x * x
+
+    _, result = heavydb.sql_execute('SELECT power_2(3);')
+    # magictoken.external_functions.printf.end
+    assert list(result) == [(9,)]
+
+
+def test_raise_exception(heavydb):
+    # magictoken.raise_exception.begin
+    @heavydb('int32(TableFunctionManager, Column<int>, OutputColumn<int>)')
+    def udtf_copy(mgr, inp, out):
+        size = len(inp)
+        if size > 4:
+            # error message must be known at compile-time
+            return mgr.error_message('TableFunctionManager error_message!')
+
+        mgr.set_output_row_size(size)
+        for i in range(size):
+            out[i] = inp[i]
+        return size
+    # magictoken.raise_exception.end
+
+    col = 'i4'
+    table_name = heavydb.table_name
+
+    query = f'''
+        SELECT
+          *
+        FROM
+            TABLE(udtf_copy(
+                cursor(SELECT {col} FROM {table_name})
+            ))
+    '''
+
+    with pytest.raises(HeavyDBServerError) as exc:
+        heavydb.sql_execute(query)
+    exc_msg = ('Error executing table function: TableFunctionManager '
+               'error_message!')
+    assert exc.match(exc_msg)
+
+
+def test_devices(heavydb):
+    # magictoken.devices.begin
+    @heavydb('int32(int32, int32)', devices=['CPU', 'GPU'])
+    def add(a, b):
+        return a + b
+    # magictoken.devices.end
+    _, result = heavydb.sql_execute('SELECT add(-3, 3);')
+    assert list(result) == [(0,)]
+
+
+def test_templates(heavydb):
+    heavydb.unregister()
+
+    # magictoken.templates.begin
+    @heavydb('Z(T, Z)', T=['int32', 'float'], Z=['int64', 'double'])
+    def add(a, b):
+        return a + b
+
+    heavydb.register()
+    assert heavydb.function_names(runtime_only=True) == ['add']
+    assert len(heavydb.function_details('add')) == 4
+    # magictoken.templates.end

--- a/rbc/tests/heavydb/test_howtos.py
+++ b/rbc/tests/heavydb/test_howtos.py
@@ -53,6 +53,7 @@ def test_external_functions(heavydb):
 
 def test_raise_exception(heavydb):
     heavydb.unregister()
+
     # magictoken.raise_exception.begin
     @heavydb('int32(TableFunctionManager, Column<int64>, OutputColumn<int64>)')
     def udtf_copy(mgr, inp, out):
@@ -68,7 +69,7 @@ def test_raise_exception(heavydb):
     # magictoken.raise_exception.end
 
     # magictoken.raise_exception.sql.begin
-    query = f'''
+    query = '''
         SELECT * FROM TABLE(udtf_copy(
             cursor(SELECT * FROM TABLE(generate_series(1, 5, 1)))
         ));
@@ -84,6 +85,7 @@ def test_raise_exception(heavydb):
 
 def test_devices(heavydb):
     heavydb.unregister()
+
     # magictoken.devices.begin
     @heavydb('int32(int32, int32)', devices=['CPU', 'GPU'])
     def add(a, b):
@@ -115,6 +117,7 @@ def test_templates(heavydb):
 
 def test_udf(heavydb):
     heavydb.unregister()
+
     # magictoken.udf.begin
     @heavydb('int64(int64)')
     def incr(a):
@@ -154,7 +157,7 @@ def test_udtf(heavydb):
     # magictoken.udtf.end
 
     # magictoken.udtf.sql.begin
-    query = f'''
+    query = '''
         SELECT * FROM TABLE(my_copy(
             cursor(SELECT * FROM TABLE(generate_series(1, 5, 1)))
         ));
@@ -213,9 +216,8 @@ def test_udf_dict_proxy(heavydb):
 
 def test_udtf_string_proxy(heavydb):
     heavydb.unregister()
-    # magictoken.udtf.proxy.begin
-    from rbc.heavydb import StringDictionaryProxy, TextEncodingNone
 
+    # magictoken.udtf.proxy.begin
     @heavydb('int32(TableFunctionManager, Column<T>, OutputColumn<T> | input_id=args<0>)',
              T=['TextEncodingDict'])
     def test_string_proxy(mgr, inp, out):
@@ -319,9 +321,9 @@ def test_array(heavydb):
     assert list(r) == [([1, 1, 1, 1, 1],)]
     # magictoken.udf.array.array_api.sql.end
 
+
 def test_tablefunctionmanager(heavydb):
     heavydb.unregister()
-    table = heavydb.table_name
 
     # magictoken.udtf.mgr.basic.begin
     @heavydb('int32(TableFunctionManager, Column<int64>, OutputColumn<int64>)')
@@ -334,7 +336,7 @@ def test_tablefunctionmanager(heavydb):
     # magictoken.udtf.mgr.basic.end
 
     # magictoken.udtf.mgr.basic.sql.begin
-    query = f'''
+    query = '''
         SELECT * FROM TABLE(table_copy(
             cursor(SELECT * FROM TABLE(generate_series(0, 4, 1)))
         ))
@@ -391,7 +393,7 @@ def test_column_power(heavydb):
     # magictoken.udtf.column.basic.end
 
     # magictoken.udtf.column.basic.sql.begin
-    query = f'''
+    query = '''
         SELECT * FROM TABLE(udtf_power(
             cursor(SELECT * FROM TABLE(generate_series(1, 5, 1))),
             3
@@ -421,7 +423,7 @@ def test_geopoint(heavydb: RemoteHeavyDB):
     # magictoken.udtf.geopoint.basic.end
 
     # magictoken.udtf.geopoint.basic.sql.begin
-    query = f'''
+    query = '''
         SELECT * FROM TABLE(
             generate_geo(5)
         );
@@ -452,7 +454,7 @@ def test_geomultipoint(heavydb: RemoteHeavyDB):
     # magictoken.udtf.mp.basic.end
 
     # magictoken.udtf.mp.basic.sql.begin
-    query = f'''
+    query = '''
         SELECT * FROM TABLE(
             generate_geo(3)
         );

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,7 @@ thriftpy2
 netifaces
 clang==11.1.0
 furo
+myst-parser
 packaging
 setuptools
 urllib3<2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,6 +6,7 @@ netifaces
 clang==11.1.0
 furo
 myst-parser
+sphinx-design
 packaging
 setuptools
 urllib3<2


### PR DESCRIPTION
This pull request adds two new sections to RBC ReadTheDocs page:
- How To
- Tutorials

This refactoring aims to enhance the clarity and structure of the text, and it is based on [diataxis](https://diataxis.fr/) guide on documentation. How-to guides are supposed to be concise and provide direct answers to specific questions (i.e. "How to connect to the HeavyDB server"). On the other hand, tutorials should be more comprehensive and in-depth exploration of a subject.